### PR TITLE
セルイベントのサイズを設定出来るように

### DIFF
--- a/Assets/HK/AutoAnt/DataSources/Cell/ClickEvents/AcquireMoney/Interval/10.asset
+++ b/Assets/HK/AutoAnt/DataSources/Cell/ClickEvents/AcquireMoney/Interval/10.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: 10
   m_EditorClassIdentifier: 
   condition: {fileID: 11400000, guid: 4c0900e2970f54676923b8814d79aff7, type: 2}
-  size: 2
+  size: 3
   gimmickPrefab: {fileID: 1696405967700200454, guid: 81339a340327d4660946cc3c5dee835b,
     type: 3}
-  intervalSeconds: 1
-  amount: 10
+  intervalSeconds: 0.2
+  amount: 25

--- a/Assets/HK/AutoAnt/DataSources/Cell/ClickEvents/AcquireMoney/Interval/10.asset
+++ b/Assets/HK/AutoAnt/DataSources/Cell/ClickEvents/AcquireMoney/Interval/10.asset
@@ -13,6 +13,7 @@ MonoBehaviour:
   m_Name: 10
   m_EditorClassIdentifier: 
   condition: {fileID: 11400000, guid: 4c0900e2970f54676923b8814d79aff7, type: 2}
+  size: 2
   gimmickPrefab: {fileID: 1696405967700200454, guid: 81339a340327d4660946cc3c5dee835b,
     type: 3}
   intervalSeconds: 1

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Cell.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Cell.cs
@@ -61,7 +61,7 @@ namespace HK.AutoAnt.CellControllers
         {
             Assert.IsTrue(this.HasEvent);
 
-            this.cellMapper.Remove(this.cellMapper.EventMap[this.Position]);
+            this.cellMapper.Remove(this.cellMapper.CellEvent.Map[this.Position]);
         }
 
         public void OnClickDown()
@@ -75,7 +75,7 @@ namespace HK.AutoAnt.CellControllers
                 return;
             }
 
-            this.cellMapper.EventMap[this.Position].OnClick(this);
+            this.cellMapper.CellEvent.Map[this.Position].OnClick(this);
         }
 
         public IObservable<ReleasedCellEvent> ReleasedCellEventAsObservable()

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Cell.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Cell.cs
@@ -113,7 +113,7 @@ namespace HK.AutoAnt.CellControllers
             this.gimmickController = this.cellEvent.CreateGimmickController();
             this.gimmickController.transform.SetParent(this.CachedTransform);
             this.gimmickController.transform.localPosition = new Vector3(0.0f, constants.Scale.y, 0.0f);
-            this.gimmickController.transform.localScale = constants.EffectScale;
+            // this.gimmickController.transform.localScale = constants.EffectScale;
         }
 
         private void DestroyGimmickController()

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Cell.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Cell.cs
@@ -27,22 +27,18 @@ namespace HK.AutoAnt.CellControllers
 
         private readonly IMessageBroker Broker = new MessageBroker();
 
-        private ICellEvent cellEvent = null;
-
         private CellMapper cellMapper;
 
         public Transform CachedTransform{ get; private set; }
 
         private CellGimmickController gimmickController;
 
-        public bool HasEvent => this.cellEvent != null;
-
         void Awake()
         {
             this.CachedTransform = this.transform;
         }
 
-        public Cell Initialize(Vector2Int position, CellType cellType, ICellEvent cellEvent, CellMapper cellMapper)
+        public Cell Initialize(Vector2Int position, CellType cellType, CellMapper cellMapper)
         {
             this.Position = position;
             this.Type = cellType;
@@ -55,35 +51,17 @@ namespace HK.AutoAnt.CellControllers
             this.boxCollider.size = constants.Scale;
 
             this.cellMapper.Add(this);
-            this.AddEvent(cellEvent);
 
             return this;
         }
 
-        public void AddEvent(ICellEvent cellEvent)
-        {
-            if(this.cellEvent != null)
-            {
-                this.Broker.Publish(ReleasedCellEvent.Get());
-            }
-
-            this.cellEvent = cellEvent;
-            if(this.cellEvent != null)
-            {
-                this.cellMapper.RegisterHasEvent(this);
-                this.cellEvent.OnRegister(this);
-                this.CreateGimmickController();
-            }
-            else
-            {
-                this.cellMapper.RegisterNotHasEvent(this);
-                this.DestroyGimmickController();
-            }
-        }
+        public bool HasEvent => this.cellMapper.HasEvent(this);
 
         public void ClearEvent()
         {
-            this.AddEvent(null);
+            Assert.IsTrue(this.HasEvent);
+
+            this.cellMapper.Remove(this.cellMapper.EventMap[this.Position]);
         }
 
         public void OnClickDown()
@@ -92,28 +70,17 @@ namespace HK.AutoAnt.CellControllers
 
         public void OnClickUp()
         {
-            if(this.cellEvent == null)
+            if(!this.HasEvent)
             {
                 return;
             }
 
-            this.cellEvent.OnClick(this);
+            this.cellMapper.EventMap[this.Position].OnClick(this);
         }
 
         public IObservable<ReleasedCellEvent> ReleasedCellEventAsObservable()
         {
             return this.Broker.Receive<ReleasedCellEvent>();
-        }
-
-        private void CreateGimmickController()
-        {
-            this.DestroyGimmickController();
-
-            var constants = GameSystem.Instance.MasterData.Cell.Constants;
-            this.gimmickController = this.cellEvent.CreateGimmickController();
-            this.gimmickController.transform.SetParent(this.CachedTransform);
-            this.gimmickController.transform.localPosition = new Vector3(0.0f, constants.Scale.y, 0.0f);
-            // this.gimmickController.transform.localScale = constants.EffectScale;
         }
 
         private void DestroyGimmickController()

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -31,10 +31,15 @@ namespace HK.AutoAnt.CellControllers
 
         public void Generate(Cell cell)
         {
+            this.Generate(cell, this.GeneratableCellEvent);
+        }
+
+        public void Generate(Cell cell, ICellEvent cellEvent)
+        {
             Assert.IsFalse(this.cellMapper.HasEvent(cell));
-            var cellEvent = UnityEngine.Object.Instantiate(this.GeneratableCellEvent);
-            cellEvent.Initialize(cell.Position);
-            cellMapper.Add(cellEvent);
+            var cellEventInstance = UnityEngine.Object.Instantiate(this.GeneratableCellEvent);
+            cellEventInstance.Initialize(cell.Position);
+            cellMapper.Add(cellEventInstance);
         }
 
         public void Erase(Cell cell)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -32,7 +32,9 @@ namespace HK.AutoAnt.CellControllers
         public void Generate(Cell cell)
         {
             Assert.IsFalse(cell.HasEvent);
-            cell.AddEvent(this.GeneratableCellEvent);
+            var cellEvent = UnityEngine.Object.Instantiate(this.GeneratableCellEvent);
+            cellEvent.Initialize(cell.Position);
+            cellMapper.Add(cellEvent);
         }
 
         public void Erase(Cell cell)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -20,7 +20,14 @@ namespace HK.AutoAnt.CellControllers
         /// </summary>
         public int RecordId { get; set; } = 100000;
 
+        private readonly CellMapper cellMapper;
+
         private CellEvent GeneratableCellEvent => GameSystem.Instance.MasterData.CellEvent.Records.Get(this.RecordId).EventData;
+
+        public CellEventGenerator(CellMapper cellMapper)
+        {
+            this.cellMapper = cellMapper;
+        }
 
         public void Generate(Cell cell)
         {
@@ -39,7 +46,7 @@ namespace HK.AutoAnt.CellControllers
         /// </summary>
         public bool CanGenerate(Cell cell)
         {
-            return this.GeneratableCellEvent.CanGenerate(cell);
+            return this.GeneratableCellEvent.CanGenerate(cell, this.cellMapper);
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -31,7 +31,7 @@ namespace HK.AutoAnt.CellControllers
 
         public void Generate(Cell cell)
         {
-            Assert.IsFalse(cell.HasEvent);
+            Assert.IsFalse(this.cellMapper.HasEvent(cell));
             var cellEvent = UnityEngine.Object.Instantiate(this.GeneratableCellEvent);
             cellEvent.Initialize(cell.Position);
             cellMapper.Add(cellEvent);
@@ -39,8 +39,10 @@ namespace HK.AutoAnt.CellControllers
 
         public void Erase(Cell cell)
         {
-            Assert.IsTrue(cell.HasEvent);
-            cell.ClearEvent();
+            Assert.IsTrue(this.cellMapper.HasEvent(cell));
+            var cellEvent = this.cellMapper.EventMap[cell.Position];
+            this.cellMapper.Remove(cellEvent);
+            cellEvent.Remove();
         }
 
         /// <summary>

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -45,7 +45,7 @@ namespace HK.AutoAnt.CellControllers
         public void Erase(Cell cell)
         {
             Assert.IsTrue(this.cellMapper.HasEvent(cell));
-            var cellEvent = this.cellMapper.EventMap[cell.Position];
+            var cellEvent = this.cellMapper.CellEvent.Map[cell.Position];
             this.cellMapper.Remove(cellEvent);
             cellEvent.Remove();
         }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellGenerator.cs
@@ -22,17 +22,17 @@ namespace HK.AutoAnt.CellControllers
             this.cellParent = cellParent;
         }
 
-        public Cell Generate(int recordId, Vector2Int position, ICellEvent clickEvent)
+        public Cell Generate(int recordId, Vector2Int position)
         {
             var record = GameSystem.Instance.MasterData.Cell.Records.Get(recordId);
             var cell = Object.Instantiate(record.Prefab)
-                .Initialize(position, record.CellType, clickEvent, this.cellMapper);
+                .Initialize(position, record.CellType, this.cellMapper);
             cell.CachedTransform.SetParent(this.cellParent);
 
             return cell;
         }
 
-        public Cell Replace(int recordId, Vector2Int position, ICellEvent clickEvent)
+        public Cell Replace(int recordId, Vector2Int position)
         {
             Assert.IsTrue(this.cellMapper.Map.ContainsKey(position), $"position = {position}にセルがないのにReplace関数が実行されました");
             
@@ -40,7 +40,7 @@ namespace HK.AutoAnt.CellControllers
             this.cellMapper.Remove(oldCell);
             Object.Destroy(oldCell.gameObject);
 
-            return this.Generate(recordId, position, clickEvent);
+            return this.Generate(recordId, position);
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellGenerator.cs
@@ -34,9 +34,9 @@ namespace HK.AutoAnt.CellControllers
 
         public Cell Replace(int recordId, Vector2Int position)
         {
-            Assert.IsTrue(this.cellMapper.Map.ContainsKey(position), $"position = {position}にセルがないのにReplace関数が実行されました");
+            Assert.IsTrue(this.cellMapper.Cell.Map.ContainsKey(position), $"position = {position}にセルがないのにReplace関数が実行されました");
             
-            var oldCell = this.cellMapper.Map[position];
+            var oldCell = this.cellMapper.Cell.Map[position];
             this.cellMapper.Remove(oldCell);
             Object.Destroy(oldCell.gameObject);
 

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellManager.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellManager.cs
@@ -28,7 +28,7 @@ namespace HK.AutoAnt.CellControllers
         void Awake()
         {
             this.Generator = new CellGenerator(this.Mapper, this.parent);
-            this.EventGenerator = new CellEventGenerator();
+            this.EventGenerator = new CellEventGenerator(this.Mapper);
 
             this.fieldInitializer.Generate(this);
         }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellManager.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellManager.cs
@@ -21,13 +21,13 @@ namespace HK.AutoAnt.CellControllers
 
         public CellMapper Mapper { get; private set; } = new CellMapper();
 
-        public CellGenerator Generator { get; private set; }
+        public CellGenerator CellGenerator { get; private set; }
 
         public CellEventGenerator EventGenerator { get; private set; }
 
         void Awake()
         {
-            this.Generator = new CellGenerator(this.Mapper, this.parent);
+            this.CellGenerator = new CellGenerator(this.Mapper, this.parent);
             this.EventGenerator = new CellEventGenerator(this.Mapper);
 
             this.fieldInitializer.Generate(this);

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
@@ -38,6 +38,7 @@ namespace HK.AutoAnt.CellControllers
         private readonly List<ICellEvent> cellEvents = new List<ICellEvent>();
 
         private readonly Dictionary<Vector2Int, ICellEvent> eventMap = new Dictionary<Vector2Int, ICellEvent>();
+        public IReadOnlyDictionary<Vector2Int, ICellEvent> EventMap => this.eventMap;
 
         public void Add(Cell cell)
         {
@@ -76,6 +77,24 @@ namespace HK.AutoAnt.CellControllers
 
             this.cells.Remove(cell);
             this.map.Remove(position);
+        }
+
+        public void Remove(ICellEvent cellEvent)
+        {
+            Assert.IsNotNull(cellEvent);
+
+            var position = cellEvent.Position;
+            this.cellEvents.Remove(cellEvent);
+
+            for (var y = 0; y < cellEvent.Size; y++)
+            {
+                for (var x = 0; x < cellEvent.Size; x++)
+                {
+                    var p = position + new Vector2Int(x, y);
+                    Assert.IsTrue(this.eventMap.ContainsKey(p));
+                    eventMap.Remove(p);
+                }
+            }
         }
 
         public bool HasEvent(Cell cell)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
@@ -167,24 +167,13 @@ namespace HK.AutoAnt.CellControllers
 
         public interface IReadonlyElement<Key, Value>
         {
-            IReadOnlyList<Value> List { get; }
-
-            IReadOnlyDictionary<Key, Value> Map { get; }
-        }
-
-        public class Element<Key, Value> : IReadonlyElement<Key, Value>
-        {
-            private readonly List<Value> list = new List<Value>();
-
             /// <summary>
             /// 全要素を持つリスト
             /// </summary>
             /// <remarks>
             /// 全検索などはこれを利用してください
             /// </remarks>
-            public List<Value> List => this.list;
-
-            private readonly Dictionary<Key, Value> map = new Dictionary<Key, Value>();
+            IReadOnlyList<Value> List { get; }
 
             /// <summary>
             /// 紐づけされたマップ
@@ -192,11 +181,18 @@ namespace HK.AutoAnt.CellControllers
             /// <remarks>
             /// <see cref="cell"/>の場合は座標と紐付けられているため、座標で検索したい場合はこれを利用してください
             /// </remarks>
-            public Dictionary<Key, Value> Map => this.map;
+            IReadOnlyDictionary<Key, Value> Map { get; }
+        }
 
-            IReadOnlyList<Value> IReadonlyElement<Key, Value>.List => this.list;
+        public class Element<Key, Value> : IReadonlyElement<Key, Value>
+        {
+            private readonly List<Value> list = new List<Value>();
 
-            IReadOnlyDictionary<Key, Value> IReadonlyElement<Key, Value>.Map => this.map;
+            private readonly Dictionary<Key, Value> map = new Dictionary<Key, Value>();
+
+            public IReadOnlyList<Value> List => this.list;
+
+            public IReadOnlyDictionary<Key, Value> Map => this.map;
 
             public void Add(Key key, Value value)
             {

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
@@ -126,6 +126,56 @@ namespace HK.AutoAnt.CellControllers
         }
 
         /// <summary>
+        /// <paramref name="origin"/>を原点とした範囲の座標を評価する
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="size"/>が<c>(2, 2)</c>の場合は以下の範囲を評価する
+        /// o = origin
+        /// x = range
+        /// xx
+        /// ox
+        /// </remarks>
+        public Vector2Int[] GetRange(Vector2Int origin, Vector2Int size, Func<Vector2Int, bool> selector)
+        {
+            Assert.IsTrue(size.x >= 0);
+            Assert.IsTrue(size.y >= 0);
+
+            var result = new List<Vector2Int>();
+
+            for (var y = 0; y < size.y; y++)
+            {
+                for (var x = 0; x < size.x; x++)
+                {
+                    var position = origin + new Vector2Int(x, y);
+                    if (!selector(position))
+                    {
+                        continue;
+                    }
+
+                    result.Add(position);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        /// <summary>
+        /// <paramref name="positions"/>に存在する全てのセルを返す
+        /// </summary>
+        public Cell[] GetCells(Vector2Int[] positions)
+        {
+            var result = new Cell[positions.Length];
+            for (var i = 0; i < positions.Length; i++)
+            {
+                var position = positions[i];
+                Assert.IsTrue(this.Map.ContainsKey(position));
+                result[i] = this.Map[position];
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// 指定した範囲でセルが配置されていない座標を返す
         /// </summary>
         public Vector2Int[] GetEmptyPositions(Vector2Int origin, int range)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using HK.AutoAnt.CellControllers.Events;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -34,6 +35,10 @@ namespace HK.AutoAnt.CellControllers
         private readonly List<Vector2Int> notHasEventCellIds = new List<Vector2Int>();
         public IReadOnlyList<Vector2Int> NotHasEventCellIds => this.notHasEventCellIds;
 
+        private readonly List<ICellEvent> cellEvents = new List<ICellEvent>();
+
+        private readonly Dictionary<Vector2Int, ICellEvent> eventMap = new Dictionary<Vector2Int, ICellEvent>();
+
         public void Add(Cell cell)
         {
             var position = cell.Position;
@@ -45,6 +50,23 @@ namespace HK.AutoAnt.CellControllers
             this.map.Add(position, cell);
         }
 
+        public void Add(ICellEvent cellEvent)
+        {
+            var position = cellEvent.Position;
+            Assert.IsTrue(this.Map.ContainsKey(position), $"position = {position}にセルが無いのにイベントが登録されました");
+            this.cellEvents.Add(cellEvent);
+
+            for (var y = 0; y < cellEvent.Size; y++)
+            {
+                for (var x = 0; x < cellEvent.Size; x++)
+                {
+                    var p = position + new Vector2Int(x, y);
+                    Assert.IsFalse(this.eventMap.ContainsKey(p), $"{p}には既にイベントが登録されています");
+                    this.eventMap.Add(p, cellEvent);
+                }
+            }
+        }
+
         public void Remove(Cell cell)
         {
             var position = cell.Position;
@@ -54,6 +76,11 @@ namespace HK.AutoAnt.CellControllers
 
             this.cells.Remove(cell);
             this.map.Remove(position);
+        }
+
+        public bool HasEvent(Cell cell)
+        {
+            return this.eventMap.ContainsKey(cell.Position);
         }
 
         /// <summary>

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
@@ -23,18 +23,6 @@ namespace HK.AutoAnt.CellControllers
         private readonly Dictionary<Vector2Int, Cell> map = new Dictionary<Vector2Int, Cell>();
         public IReadOnlyDictionary<Vector2Int, Cell> Map => this.map;
 
-        /// <summary>
-        /// イベントを持つ<see cref="Cell.Position"/>
-        /// </summary>
-        private readonly List<Vector2Int> hasEventCellIds = new List<Vector2Int>();
-        public IReadOnlyList<Vector2Int> HasEventCellIds => this.hasEventCellIds;
-
-        /// <summary>
-        /// イベントが無い<see cref="Cell.Position"/>
-        /// </summary>
-        private readonly List<Vector2Int> notHasEventCellIds = new List<Vector2Int>();
-        public IReadOnlyList<Vector2Int> NotHasEventCellIds => this.notHasEventCellIds;
-
         private readonly List<ICellEvent> cellEvents = new List<ICellEvent>();
 
         private readonly Dictionary<Vector2Int, ICellEvent> eventMap = new Dictionary<Vector2Int, ICellEvent>();
@@ -100,33 +88,6 @@ namespace HK.AutoAnt.CellControllers
         public bool HasEvent(Cell cell)
         {
             return this.eventMap.ContainsKey(cell.Position);
-        }
-
-        /// <summary>
-        /// イベントを持たない<see cref="Cell"/>として登録する
-        /// </summary>
-        public void RegisterNotHasEvent(Cell cell)
-        {
-            var position = cell.Position;
-            Assert.IsNotNull(cell);
-            Assert.IsFalse(cell.HasEvent);
-
-            this.hasEventCellIds.Remove(position);
-            this.notHasEventCellIds.Add(position);
-        }
-
-        /// <summary>
-        /// イベントを持つ<see cref="Cell"/>として登録する
-        /// </summary>
-        public void RegisterHasEvent(Cell cell)
-        {
-            var position = cell.Position;
-            Assert.IsNotNull(cell);
-            Assert.IsTrue(cell.HasEvent);
-            Assert.IsFalse(this.hasEventCellIds.Contains(position), $"{position}はすでにイベントを持っています");
-
-            this.hasEventCellIds.Add(position);
-            this.notHasEventCellIds.Remove(position);
         }
 
         /// <summary>

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellMapper.cs
@@ -41,7 +41,7 @@ namespace HK.AutoAnt.CellControllers
 
         public void Add(ICellEvent cellEvent)
         {
-            var position = cellEvent.Position;
+            var position = cellEvent.Origin;
             Assert.IsTrue(this.Map.ContainsKey(position), $"position = {position}にセルが無いのにイベントが登録されました");
             this.cellEvents.Add(cellEvent);
 
@@ -71,7 +71,7 @@ namespace HK.AutoAnt.CellControllers
         {
             Assert.IsNotNull(cellEvent);
 
-            var position = cellEvent.Position;
+            var position = cellEvent.Origin;
             this.cellEvents.Remove(cellEvent);
 
             for (var y = 0; y < cellEvent.Size; y++)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/AcquireMoneyInterval.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/AcquireMoneyInterval.cs
@@ -26,15 +26,16 @@ namespace HK.AutoAnt.CellControllers.Events
         [SerializeField]
         private int amount = 0;
 
-        public override void OnRegister(Cell owner)
+        public override void Initialize(Vector2Int position)
         {
+            base.Initialize(position);
+
             Observable.Interval(TimeSpan.FromSeconds(this.intervalSeconds))
-                .TakeUntil(owner.ReleasedCellEventAsObservable())
                 .SubscribeWithState(this, (_, _this) =>
                 {
                     GameSystem.Instance.User.Wallet.AddMoney(_this.amount);
                 })
-                .AddTo(owner);
+                .AddTo(this.instanceEvents);
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using HK.AutoAnt.CellControllers.Gimmicks;
+using UniRx;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -18,6 +19,11 @@ namespace HK.AutoAnt.CellControllers.Events
         public int Size => this.size;
 
         public Vector2Int Position { get; protected set; }
+
+        /// <summary>
+        /// 実体が持つイベント
+        /// </summary>
+        protected readonly CompositeDisposable instanceEvents = new CompositeDisposable();
 
         protected CellGimmickController gimmick;
 
@@ -38,6 +44,7 @@ namespace HK.AutoAnt.CellControllers.Events
 
         public virtual void Remove()
         {
+            this.instanceEvents.Clear();
             Destroy(this.gimmick.gameObject);
         }
 
@@ -61,10 +68,6 @@ namespace HK.AutoAnt.CellControllers.Events
             }
 
             return this.condition.Evalute(cells);
-        }
-
-        public virtual void OnRegister(Cell owner)
-        {
         }
 
         public virtual void OnClick(Cell owner)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -18,7 +18,7 @@ namespace HK.AutoAnt.CellControllers.Events
         protected int size = 1;
         public int Size => this.size;
 
-        public Vector2Int Position { get; protected set; }
+        public Vector2Int Origin { get; protected set; }
 
         /// <summary>
         /// 実体が持つイベント
@@ -38,7 +38,7 @@ namespace HK.AutoAnt.CellControllers.Events
 
         public virtual void Initialize(Vector2Int position)
         {
-            this.Position = position;
+            this.Origin = position;
             this.gimmick = this.CreateGimmickController();
         }
 

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -11,8 +11,24 @@ namespace HK.AutoAnt.CellControllers.Events
     {
         [SerializeField]
         private CellEventGenerateCondition condition;
-        
+
+        /// <summary>
+        /// 必要なセルのサイズ
+        /// </summary>
+        [SerializeField]
+        private Vector2Int size = Vector2Int.one;
+
         public abstract CellGimmickController CreateGimmickController();
+
+#if UNITY_EDITOR
+        protected virtual void OnValidate()
+        {
+            var newSize = this.size;
+            newSize.x = newSize.x <= 1 ? 1 : newSize.x;
+            newSize.y = newSize.y <= 1 ? 1 : newSize.y;
+            this.size = newSize;
+        }
+#endif
 
         public bool CanGenerate(Cell owner)
         {

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -36,6 +36,11 @@ namespace HK.AutoAnt.CellControllers.Events
             this.gimmick = this.CreateGimmickController();
         }
 
+        public virtual void Remove()
+        {
+            Destroy(this.gimmick.gameObject);
+        }
+
         public bool CanGenerate(Cell origin, CellMapper cellMapper)
         {
             Assert.IsNotNull(this.condition);

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -52,7 +52,7 @@ namespace HK.AutoAnt.CellControllers.Events
         {
             Assert.IsNotNull(this.condition);
 
-            var cellPositions = cellMapper.GetRange(origin.Position, Vector2Int.one * this.size, p => cellMapper.Map.ContainsKey(p));
+            var cellPositions = cellMapper.GetRange(origin.Position, Vector2Int.one * this.size, p => cellMapper.Cell.Map.ContainsKey(p));
 
             // 配置したいところにセルがない場合は生成できない
             if(cellPositions.Length != this.size * this.size)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -13,39 +13,44 @@ namespace HK.AutoAnt.CellControllers.Events
         [SerializeField]
         private CellEventGenerateCondition condition;
 
-        /// <summary>
-        /// 必要なセルのサイズ
-        /// </summary>
         [SerializeField]
-        private Vector2Int size = Vector2Int.one;
+        protected int size = 1;
+        public int Size => this.size;
+
+        public Vector2Int Position { get; protected set; }
+
+        protected CellGimmickController gimmick;
 
         public abstract CellGimmickController CreateGimmickController();
 
 #if UNITY_EDITOR
         protected virtual void OnValidate()
         {
-            var newSize = this.size;
-            newSize.x = newSize.x <= 1 ? 1 : newSize.x;
-            newSize.y = newSize.y <= 1 ? 1 : newSize.y;
-            this.size = newSize;
+            this.size = this.size <= 1 ? 1 : this.size;
         }
 #endif
+
+        public virtual void Initialize(Vector2Int position)
+        {
+            this.Position = position;
+            this.gimmick = this.CreateGimmickController();
+        }
 
         public bool CanGenerate(Cell origin, CellMapper cellMapper)
         {
             Assert.IsNotNull(this.condition);
 
-            var cellPositions = cellMapper.GetRange(origin.Position, this.size, p => cellMapper.Map.ContainsKey(p));
+            var cellPositions = cellMapper.GetRange(origin.Position, Vector2Int.one * this.size, p => cellMapper.Map.ContainsKey(p));
 
             // 配置したいところにセルがない場合は生成できない
-            if(cellPositions.Length != this.TotalSize)
+            if(cellPositions.Length != this.size * this.size)
             {
                 return false;
             }
 
             // 配置したいセルにイベントがあった場合は生成できない
             var cells = cellMapper.GetCells(cellPositions);
-            if(Array.FindIndex(cells, c => c.HasEvent) != -1)
+            if(Array.FindIndex(cells, c => cellMapper.HasEvent(c)) != -1)
             {
                 return false;
             }
@@ -59,22 +64,6 @@ namespace HK.AutoAnt.CellControllers.Events
 
         public virtual void OnClick(Cell owner)
         {
-        }
-
-        private int TotalSize
-        {
-            get
-            {
-                if(this.size == Vector2Int.one)
-                {
-                    return 1;
-                }
-
-                var x = this.size.x <= 1 ? 0 : this.size.x;
-                var y = this.size.y <= 1 ? 0 : this.size.y;
-
-                return x + y;
-            }
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEventBlankGimmick.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEventBlankGimmick.cs
@@ -21,9 +21,12 @@ namespace HK.AutoAnt.CellControllers.Events
         {
             var gimmick = Instantiate(this.gimmickPrefab);
             var constants = GameSystem.Instance.MasterData.Cell.Constants;
-            var constantScale = constants.EffectScale;
-            gimmick.transform.position = new Vector3(this.Position.x * (constants.Scale.x + constants.Interval), 0.0f, this.Position.y * (constants.Scale.z + constants.Interval));
-            gimmick.transform.localScale = constantScale * this.size;
+            var position = new Vector3(this.Origin.x * (constants.Scale.x + constants.Interval), 0.0f, this.Origin.y * (constants.Scale.z + constants.Interval));
+            var fixedSize = this.size - 1;
+            position += new Vector3((constants.Scale.x / 2.0f) * fixedSize, 0.0f, (constants.Scale.z / 2.0f) * fixedSize);
+            position += new Vector3(constants.Interval * fixedSize, 0.0f, constants.Interval * fixedSize);
+            gimmick.transform.position = position;
+            gimmick.transform.localScale = constants.EffectScale * this.size + (Vector3.one * (constants.Interval * fixedSize));
 
             return gimmick;
         }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEventBlankGimmick.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEventBlankGimmick.cs
@@ -1,4 +1,5 @@
 ﻿using HK.AutoAnt.CellControllers.Gimmicks;
+using HK.AutoAnt.Systems;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -18,7 +19,13 @@ namespace HK.AutoAnt.CellControllers.Events
 
         public override CellGimmickController CreateGimmickController()
         {
-            return Instantiate(this.gimmickPrefab);
+            var gimmick = Instantiate(this.gimmickPrefab);
+            var constants = GameSystem.Instance.MasterData.Cell.Constants;
+            var constantScale = constants.EffectScale;
+            gimmick.transform.position = new Vector3(this.Position.x * (constants.Scale.x + constants.Interval), 0.0f, this.Position.y * (constants.Scale.z + constants.Interval));
+            gimmick.transform.localScale = constantScale * this.size;
+
+            return gimmick;
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/CellEventGenerateCondition.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/CellEventGenerateCondition.cs
@@ -8,6 +8,6 @@ namespace HK.AutoAnt.CellControllers.Events
     /// </summary>
     public abstract class CellEventGenerateCondition : ScriptableObject, ICellEventGenerateCondition
     {
-        public abstract bool Evalute(Cell cell);
+        public abstract bool Evalute(Cell[] cells);
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/CellTypeConditionBlackList.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/CellTypeConditionBlackList.cs
@@ -14,9 +14,17 @@ namespace HK.AutoAnt.CellControllers.Events
         [SerializeField]
         private CellType[] blackList;
         
-        public override bool Evalute(Cell cell)
+        public override bool Evalute(Cell[] cells)
         {
-            return Array.FindIndex(this.blackList, c => c == cell.Type) <= -1;
+            foreach(var cell in cells)
+            {
+                if(Array.FindIndex(this.blackList, c => c == cell.Type) >= 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/ICellEventGenerateCondition.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/ICellEventGenerateCondition.cs
@@ -11,6 +11,6 @@ namespace HK.AutoAnt.CellControllers.Events
         /// <summary>
         /// 作成可能か返す
         /// </summary>
-        bool Evalute(Cell cell);
+        bool Evalute(Cell[] cells);
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/TrueCondition.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Conditions/TrueCondition.cs
@@ -9,7 +9,7 @@ namespace HK.AutoAnt.CellControllers.Events
     [CreateAssetMenu(menuName = "AutoAnt/Cell/Event/Condition/True")]
     public sealed class TrueCondition : CellEventGenerateCondition
     {
-        public override bool Evalute(Cell cell)
+        public override bool Evalute(Cell[] cells)
         {
             return true;
         }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
@@ -10,9 +10,9 @@ namespace HK.AutoAnt.CellControllers.Events
     public interface ICellEvent
     {
         /// <summary>
-        /// 座標
+        /// 原点座標
         /// </summary>
-        Vector2Int Position { get; }
+        Vector2Int Origin { get; }
 
         /// <summary>
         /// セルサイズ

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
@@ -28,6 +28,11 @@ namespace HK.AutoAnt.CellControllers.Events
         void Initialize(Vector2Int position);
 
         /// <summary>
+        /// 削除処理
+        /// </summary>
+        void Remove();
+
+        /// <summary>
         /// <see cref="CellGimmickController"/>を生成する
         /// </summary>
         CellGimmickController CreateGimmickController();

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
@@ -10,6 +10,24 @@ namespace HK.AutoAnt.CellControllers.Events
     public interface ICellEvent
     {
         /// <summary>
+        /// 座標
+        /// </summary>
+        Vector2Int Position { get; }
+
+        /// <summary>
+        /// セルサイズ
+        /// </summary>
+        /// <remarks>
+        /// 正方形にのみ対応しています
+        /// </remarks>
+        int Size { get; }
+
+        /// <summary>
+        /// 初期化
+        /// </summary>
+        void Initialize(Vector2Int position);
+
+        /// <summary>
         /// <see cref="CellGimmickController"/>を生成する
         /// </summary>
         CellGimmickController CreateGimmickController();

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
@@ -17,7 +17,7 @@ namespace HK.AutoAnt.CellControllers.Events
         /// <summary>
         /// 作成可能か返す
         /// </summary>
-        bool CanGenerate(Cell owner);
+        bool CanGenerate(Cell owner, CellMapper cellMapper);
 
         /// <summary>
         /// イベントがセルに登録された時の処理

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
@@ -43,11 +43,6 @@ namespace HK.AutoAnt.CellControllers.Events
         bool CanGenerate(Cell owner, CellMapper cellMapper);
 
         /// <summary>
-        /// イベントがセルに登録された時の処理
-        /// </summary>
-        void OnRegister(Cell owner);
-
-        /// <summary>
         /// セルがクリックされた時の処理
         /// </summary>
         void OnClick(Cell owner);

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Log.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Log.cs
@@ -13,7 +13,6 @@ namespace HK.AutoAnt.CellControllers.Events
         public override void OnClick(Cell owner)
         {
             Debug.Log($"{owner.Position}", owner);
-            owner.ClearEvent();
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/FieldInitializer.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/FieldInitializer.cs
@@ -17,9 +17,13 @@ namespace HK.AutoAnt.CellControllers
 
         public void Generate(CellManager cellManager)
         {
-            foreach(var cell in this.cells)
+            foreach(var c in this.cells)
             {
-                cellManager.Generator.Generate(cell.Id, cell.Position, cell.CellEvent);
+                var cell = cellManager.Generator.Generate(c.Id, c.Position);
+                if(c.CellEvent != null)
+                {
+                    cellManager.EventGenerator.Generate(cell, c.CellEvent);
+                }
             }
         }
 

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/FieldInitializer.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/FieldInitializer.cs
@@ -19,7 +19,7 @@ namespace HK.AutoAnt.CellControllers
         {
             foreach(var c in this.cells)
             {
-                var cell = cellManager.Generator.Generate(c.Id, c.Position);
+                var cell = cellManager.CellGenerator.Generate(c.Id, c.Position);
                 if(c.CellEvent != null)
                 {
                     cellManager.EventGenerator.Generate(cell, c.CellEvent);

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToDevelopCell.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToDevelopCell.cs
@@ -42,12 +42,12 @@ namespace HK.AutoAnt.GameControllers
                 return;
             }
 
-            this.cellGenerator.Replace(this.replaceCellRecordId, cell.Position, null);
+            this.cellGenerator.Replace(this.replaceCellRecordId, cell.Position);
 
             // 周りのセルのない座標にBlankセルを作成する　
             foreach(var position in this.cellMapper.GetEmptyPositions(cell.Position, this.generateBlankRange))
             {
-                this.cellGenerator.Generate(this.blankCellRecordId, position, null);
+                this.cellGenerator.Generate(this.blankCellRecordId, position);
             }
         }
     }

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToEraseCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToEraseCellEvent.cs
@@ -14,15 +14,18 @@ namespace HK.AutoAnt.GameControllers
     {
         private readonly CellEventGenerator eventGenerator;
 
-        public ClickToEraseCellEvent(CellEventGenerator eventGenerator)
+        private readonly CellMapper cellMapper;
+
+        public ClickToEraseCellEvent(CellEventGenerator eventGenerator, CellMapper cellMapper)
         {
             this.eventGenerator = eventGenerator;
+            this.cellMapper = cellMapper;
         }
 
         public void Do(InputControllers.Events.ClickData data)
         {
             var cell = CellManager.GetCell(GameSystem.Instance.Cameraman.Camera.ScreenPointToRay(data.Position));
-            if(cell != null && cell.HasEvent)
+            if(cell != null && this.cellMapper.HasEvent(cell))
             {
                 this.eventGenerator.Erase(cell);
             }

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
@@ -22,7 +22,7 @@ namespace HK.AutoAnt.GameControllers
         public void Do(InputControllers.Events.ClickData data)
         {
             var cell = CellManager.GetCell(GameSystem.Instance.Cameraman.Camera.ScreenPointToRay(data.Position));
-            if(cell == null || cell.HasEvent)
+            if(cell == null)
             {
                 return;
             }

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/EraseCellEventActions.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/EraseCellEventActions.cs
@@ -10,11 +10,11 @@ namespace HK.AutoAnt.GameControllers
     /// </summary>
     public sealed class EraseCellEventActions : InputActions
     {
-        public EraseCellEventActions(CellEventGenerator eventGenerator, GameCameraController gameCameraController)
+        public EraseCellEventActions(CellEventGenerator eventGenerator, CellMapper cellMapper, GameCameraController gameCameraController)
             : base(
                 null,
                 null,
-                new ClickToEraseCellEvent(eventGenerator),
+                new ClickToEraseCellEvent(eventGenerator, cellMapper),
                 new DragToMoveCamera(gameCameraController),
                 null
             )

--- a/Assets/HK/AutoAnt/Scripts/Input/GameInputController.cs
+++ b/Assets/HK/AutoAnt/Scripts/Input/GameInputController.cs
@@ -72,7 +72,7 @@ namespace HK.AutoAnt.InputControllers
             }
             if (UnityEngine.Input.GetKeyDown(KeyCode.E))
             {
-                this.inputActions = new EraseCellEventActions(this.cellManager.EventGenerator, this.gameCameraController);
+                this.inputActions = new EraseCellEventActions(this.cellManager.EventGenerator, this.cellManager.Mapper, this.gameCameraController);
             }
             if (UnityEngine.Input.GetKeyDown(KeyCode.R))
             {

--- a/Assets/HK/AutoAnt/Scripts/Input/GameInputController.cs
+++ b/Assets/HK/AutoAnt/Scripts/Input/GameInputController.cs
@@ -77,7 +77,7 @@ namespace HK.AutoAnt.InputControllers
             if (UnityEngine.Input.GetKeyDown(KeyCode.R))
             {
                 this.inputActions = new DevelopCellActions(
-                    this.cellManager.Generator,
+                    this.cellManager.CellGenerator,
                     this.cellManager.Mapper,
                     100100,
                     100000,


### PR DESCRIPTION
## 変更点概要
- タイトルの通りで、例えば3*3の建物を建てられるようになりました
    - その際に建物のサイズも自動的に適用されるようになりました

## 特に見てほしい箇所
- セルとイベントを1対1にしていたので`Cell`にイベントを持たせるのではなく`CellMapper`に持たせるようにしました

## 特に見なくていい箇所
- 無し

## その他
- 無し
