### PR TITLE
開拓する時にお金を消費するように

### DIFF
--- a/Assets/HK/AutoAnt/DataSources/Cell/FieldInitializer.asset
+++ b/Assets/HK/AutoAnt/DataSources/Cell/FieldInitializer.asset
@@ -14,77 +14,77 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   cells:
   - id: 100000
-    position: {x: 0, y: 0}
-    cellEvent: {fileID: 0}
+    position: {x: -2, y: -2}
+    cellEventRecordId: 0
   - id: 100000
+    position: {x: -1, y: -2}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: 0, y: -2}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: 1, y: -2}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: 2, y: -2}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: -2, y: -1}
+    cellEventRecordId: 0
+  - id: 100100
+    position: {x: -1, y: -1}
+    cellEventRecordId: 0
+  - id: 100100
+    position: {x: 0, y: -1}
+    cellEventRecordId: 0
+  - id: 100100
+    position: {x: 1, y: -1}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: 2, y: -1}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: -2, y: 0}
+    cellEventRecordId: 0
+  - id: 100100
+    position: {x: -1, y: 0}
+    cellEventRecordId: 0
+  - id: 100100
+    position: {x: 0, y: 0}
+    cellEventRecordId: 0
+  - id: 100100
     position: {x: 1, y: 0}
-    cellEvent: {fileID: 0}
+    cellEventRecordId: 0
   - id: 100000
     position: {x: 2, y: 0}
-    cellEvent: {fileID: 0}
+    cellEventRecordId: 0
   - id: 100000
-    position: {x: 3, y: 0}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 4, y: 0}
-    cellEvent: {fileID: 0}
-  - id: 100000
+    position: {x: -2, y: 1}
+    cellEventRecordId: 0
+  - id: 100100
+    position: {x: -1, y: 1}
+    cellEventRecordId: 0
+  - id: 100100
     position: {x: 0, y: 1}
-    cellEvent: {fileID: 0}
+    cellEventRecordId: 0
   - id: 100100
     position: {x: 1, y: 1}
-    cellEvent: {fileID: 0}
-  - id: 100100
-    position: {x: 2, y: 1}
-    cellEvent: {fileID: 0}
-  - id: 100100
-    position: {x: 3, y: 1}
-    cellEvent: {fileID: 0}
+    cellEventRecordId: 0
   - id: 100000
-    position: {x: 4, y: 1}
-    cellEvent: {fileID: 0}
+    position: {x: 2, y: 1}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: -2, y: 2}
+    cellEventRecordId: 0
+  - id: 100000
+    position: {x: -1, y: 2}
+    cellEventRecordId: 0
   - id: 100000
     position: {x: 0, y: 2}
-    cellEvent: {fileID: 0}
-  - id: 100100
+    cellEventRecordId: 0
+  - id: 100000
     position: {x: 1, y: 2}
-    cellEvent: {fileID: 0}
-  - id: 100100
+    cellEventRecordId: 0
+  - id: 100000
     position: {x: 2, y: 2}
-    cellEvent: {fileID: 0}
-  - id: 100100
-    position: {x: 3, y: 2}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 4, y: 2}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 0, y: 3}
-    cellEvent: {fileID: 0}
-  - id: 100100
-    position: {x: 1, y: 3}
-    cellEvent: {fileID: 0}
-  - id: 100100
-    position: {x: 2, y: 3}
-    cellEvent: {fileID: 0}
-  - id: 100100
-    position: {x: 3, y: 3}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 4, y: 3}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 0, y: 4}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 1, y: 4}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 2, y: 4}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 3, y: 4}
-    cellEvent: {fileID: 0}
-  - id: 100000
-    position: {x: 4, y: 4}
-    cellEvent: {fileID: 0}
+    cellEventRecordId: 0

--- a/Assets/HK/AutoAnt/Scripts/Database/MasterDataCell.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/MasterDataCell.cs
@@ -32,6 +32,13 @@ namespace HK.AutoAnt.Database
             [SerializeField]
             private float interval = 1.5f;
             public float Interval => this.interval;
+
+            /// <summary>
+            /// 開拓するためのコスト係数
+            /// </summary>
+            [SerializeField]
+            private int developCost = 10;
+            public int DevelopCost => this.developCost;
         }
 
         [Serializable]

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/Calculator.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/Calculator.cs
@@ -1,0 +1,20 @@
+﻿using HK.AutoAnt.Systems;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.GameControllers
+{
+    /// <summary>
+    /// ゲームに関する様々な計算式を定義するクラス
+    /// </summary>
+    public static class Calculator
+    {
+        /// <summary>
+        /// セルを開拓するために必要なお金を返す
+        /// </summary>
+        public static int DevelopCost(GameSystem gameSystem, Vector2Int position)
+        {
+            return gameSystem.MasterData.Cell.Constants.DevelopCost * position.sqrMagnitude;
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/Calculator.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/Calculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1157eab8dcad14c4f9c2c798af46c6f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/DevelopCellActions.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/DevelopCellActions.cs
@@ -1,5 +1,6 @@
 ﻿using HK.AutoAnt.CameraControllers;
 using HK.AutoAnt.CellControllers;
+using HK.AutoAnt.Systems;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -11,6 +12,7 @@ namespace HK.AutoAnt.GameControllers
     public sealed class DevelopCellActions : InputActions
     {
         public DevelopCellActions(
+            GameSystem gameSystem,
             CellGenerator cellGenerator,
             CellMapper cellMapper,
             int replaceCellRecordId,
@@ -22,6 +24,7 @@ namespace HK.AutoAnt.GameControllers
                 null,
                 null,
                 new ClickToDevelopCell(
+                    gameSystem,
                     cellGenerator,
                     cellMapper,
                     replaceCellRecordId,

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToDevelopCell.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToDevelopCell.cs
@@ -14,6 +14,8 @@ namespace HK.AutoAnt.GameControllers
     /// </remarks>
     public sealed class ClickToDevelopCell : IInputAction<InputControllers.Events.ClickData>
     {
+        private readonly GameSystem gameSystem;
+
         private readonly CellGenerator cellGenerator;
 
         private readonly CellMapper cellMapper;
@@ -25,8 +27,16 @@ namespace HK.AutoAnt.GameControllers
 
         private int generateBlankRange;
 
-        public ClickToDevelopCell(CellGenerator cellGenerator, CellMapper cellMapper, int replaceCellRecordId, int blankCellRecordId, int generateBlankRange)
+        public ClickToDevelopCell(
+            GameSystem gameSystem,
+            CellGenerator cellGenerator,
+            CellMapper cellMapper,
+            int replaceCellRecordId,
+            int blankCellRecordId,
+            int generateBlankRange
+            )
         {
+            this.gameSystem = gameSystem;
             this.cellGenerator = cellGenerator;
             this.cellMapper = cellMapper;
             this.replaceCellRecordId = replaceCellRecordId;
@@ -42,6 +52,13 @@ namespace HK.AutoAnt.GameControllers
                 return;
             }
 
+            var needMoney = Calculator.DevelopCost(this.gameSystem, cell.Position);
+            if(!this.gameSystem.User.Wallet.IsEnoughMoney(needMoney))
+            {
+                return;
+            }
+
+            this.gameSystem.User.Wallet.AddMoney(-needMoney);
             this.cellGenerator.Replace(this.replaceCellRecordId, cell.Position);
 
             // 周りのセルのない座標にBlankセルを作成する　

--- a/Assets/HK/AutoAnt/Scripts/Input/GameInputController.cs
+++ b/Assets/HK/AutoAnt/Scripts/Input/GameInputController.cs
@@ -87,6 +87,7 @@ namespace HK.AutoAnt.InputControllers
             if (UnityEngine.Input.GetKeyDown(KeyCode.R))
             {
                 this.inputActions = new DevelopCellActions(
+                    GameSystem.Instance,
                     this.cellManager.CellGenerator,
                     this.cellManager.Mapper,
                     100100,


### PR DESCRIPTION
## 変更点概要
- タイトルの通り

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- コストの係数は`Assets/HK/AutoAnt/DataSources/Database/Cell.asset`の`Constants.DevelopCost`に定義しています
- 現状必要なコストは以下の計算式で成り立ちます
    - `必要なお金 = DevelopCost * "開拓したい座標のsqrMagnitude"`

## 特に見なくていい箇所
- 計算式は適当 ☺️ 

## その他
- 🍐 
