### PR TITLE
セルイベントの生成履歴を保持出来るように

### DIFF
--- a/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+namespace ES3Types
+{
+	[ES3PropertiesAttribute("numbers")]
+	public class ES3Type_CellEvent : ES3ObjectType
+	{
+		public static ES3Type Instance = null;
+
+		public ES3Type_CellEvent() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent)){ Instance = this; }
+
+		protected override void WriteObject(object obj, ES3Writer writer)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent)obj;
+			
+			writer.WritePrivateField("numbers", instance);
+		}
+
+		protected override void ReadObject<T>(ES3Reader reader, object obj)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent)obj;
+			foreach(string propertyName in reader.Properties)
+			{
+				switch(propertyName)
+				{
+					
+					case "numbers":
+					reader.SetPrivateField("numbers", reader.Read<System.Collections.Generic.List<System.Int32>>(), instance);
+					break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+
+		protected override object ReadObject<T>(ES3Reader reader)
+		{
+			var instance = new HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent();
+			ReadObject<T>(reader, instance);
+			return instance;
+		}
+	}
+
+	public class ES3Type_CellEventArray : ES3ArrayType
+	{
+		public static ES3Type Instance;
+
+		public ES3Type_CellEventArray() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent[]), ES3Type_CellEvent.Instance)
+		{
+			Instance = this;
+		}
+	}
+}

--- a/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs.meta
+++ b/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7da1f8fdb4a4a4aacb6f099e18ed4cd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+namespace ES3Types
+{
+	[ES3PropertiesAttribute("histories")]
+	public class ES3Type_GenerateCellEventHistory : ES3ObjectType
+	{
+		public static ES3Type Instance = null;
+
+		public ES3Type_GenerateCellEventHistory() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory)){ Instance = this; }
+
+		protected override void WriteObject(object obj, ES3Writer writer)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory)obj;
+			
+			writer.WriteProperty("histories", instance.histories);
+		}
+
+		protected override void ReadObject<T>(ES3Reader reader, object obj)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory)obj;
+			foreach(string propertyName in reader.Properties)
+			{
+				switch(propertyName)
+				{
+					
+					case "histories":
+						instance.histories = reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>();
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+
+		protected override object ReadObject<T>(ES3Reader reader)
+		{
+			var instance = new HK.AutoAnt.UserControllers.GenerateCellEventHistory();
+			ReadObject<T>(reader, instance);
+			return instance;
+		}
+	}
+
+	public class ES3Type_GenerateCellEventHistoryArray : ES3ArrayType
+	{
+		public static ES3Type Instance;
+
+		public ES3Type_GenerateCellEventHistoryArray() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory[]), ES3Type_GenerateCellEventHistory.Instance)
+		{
+			Instance = this;
+		}
+	}
+}

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
@@ -14,7 +14,7 @@ namespace ES3Types
 		{
 			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory)obj;
 			
-			writer.WriteProperty("histories", instance.histories);
+			writer.WritePrivateField("histories", instance);
 		}
 
 		protected override void ReadObject<T>(ES3Reader reader, object obj)
@@ -26,8 +26,8 @@ namespace ES3Types
 				{
 					
 					case "histories":
-						instance.histories = reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>();
-						break;
+					reader.SetPrivateField("histories", reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>(), instance);
+					break;
 					default:
 						reader.Skip();
 						break;

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
@@ -26,7 +26,7 @@ namespace ES3Types
 				{
 					
 					case "histories":
-					reader.SetPrivateField("histories", reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>(), instance);
+					reader.SetPrivateField("histories", reader.Read<System.Collections.Generic.Dictionary<System.Int32, HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent>>(), instance);
 					break;
 					default:
 						reader.Skip();

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs.meta
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cbd73e7fbc1249f99680464d3c535be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Easy Save 3/Types/ES3Type_SerializableUser.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_SerializableUser.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace ES3Types
 {
-	[ES3PropertiesAttribute("Wallet", "Inventory")]
+	[ES3PropertiesAttribute("Wallet", "Inventory", "GenerateCellEventHistory")]
 	public class ES3Type_SerializableUser : ES3ObjectType
 	{
 		public static ES3Type Instance = null;
@@ -16,6 +16,7 @@ namespace ES3Types
 			
 			writer.WriteProperty("Wallet", instance.Wallet, ES3Type_SerializableWallet.Instance);
 			writer.WriteProperty("Inventory", instance.Inventory, ES3Type_Inventory.Instance);
+			writer.WriteProperty("GenerateCellEventHistory", instance.GenerateCellEventHistory, ES3Type_GenerateCellEventHistory.Instance);
 		}
 
 		protected override void ReadObject<T>(ES3Reader reader, object obj)
@@ -31,6 +32,9 @@ namespace ES3Types
 						break;
 					case "Inventory":
 						instance.Inventory = reader.Read<HK.AutoAnt.UserControllers.Inventory>(ES3Type_Inventory.Instance);
+						break;
+					case "GenerateCellEventHistory":
+						instance.GenerateCellEventHistory = reader.Read<HK.AutoAnt.UserControllers.GenerateCellEventHistory>(ES3Type_GenerateCellEventHistory.Instance);
 						break;
 					default:
 						reader.Skip();

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -52,7 +52,7 @@ namespace HK.AutoAnt.CellControllers
             cellEventInstance.Initialize(cell.Position, this.gameSystem, isInitializingGame);
             cellMapper.Add(cellEventInstance);
 
-            this.gameSystem.User.GenerateCellEventHistory.AddHistory(cellEventRecordId);
+            this.gameSystem.User.GenerateCellEventHistory.AddHistory(cellEventRecordId, 0);
         }
 
         public void GenerateOnDeserialize(CellEvent instance)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -51,6 +51,8 @@ namespace HK.AutoAnt.CellControllers
             cellEventInstance.name = cellEventRecord.EventData.name;
             cellEventInstance.Initialize(cell.Position, this.gameSystem, isInitializingGame);
             cellMapper.Add(cellEventInstance);
+
+            this.gameSystem.User.GenerateCellEventHistory.AddHistory(cellEventRecordId);
         }
 
         public void GenerateOnDeserialize(CellEvent instance)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Housing.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Housing.cs
@@ -79,6 +79,7 @@ namespace HK.AutoAnt.CellControllers.Events
         {
             this.LevelUp(this.gameSystem);
             this.levelParameter = this.gameSystem.MasterData.HousingLevelParameter.Records.Get(this.Id, this.Level);
+            this.gameSystem.User.GenerateCellEventHistory.AddHistory(this.Id, this.Level - 1);
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Linq;
 using HK.AutoAnt.Systems;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -33,6 +34,16 @@ public partial class SROptions
         foreach(var record in masterData.Records)
         {
             GameSystem.Instance.User.Inventory.AddItem(record, 10);
+        }
+    }
+
+    [Category(UserCategory)]
+    [DisplayName("建設履歴を表示する")]
+    public void PrintGenerateCellEventHistories()
+    {
+        foreach(var h in GameSystem.Instance.User.GenerateCellEventHistory.Histories)
+        {
+            Debug.Log($"CellEventRecordId = {h.Key}, numbers = {string.Join(",", h.Value.Numbers.Select(n => n.ToString()))}");
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs
@@ -1,0 +1,24 @@
+﻿using HK.AutoAnt.Database;
+using HK.AutoAnt.UserControllers;
+using HK.Framework.EventSystems;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.Events
+{
+    /// <summary>
+    /// セルイベント生成の履歴が追加された際のイベント
+    /// </summary>
+    public sealed class AddedGenerateCellEventHistory : Message<AddedGenerateCellEventHistory, GenerateCellEventHistory, int>
+    {
+        /// <summary>
+        /// 追加された<see cref="GenerateCellEventHistory"/>
+        /// </summary>
+        public GenerateCellEventHistory GenerateCellEventHistory => this.param1;
+
+        /// <summary>
+        /// 追加されたセルイベントのレコードID
+        /// </summary>
+        public int CellEventRecordId => this.param2;
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56eeccbaed47a4a6baa1ebc654d95dad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/SaveData/Serializable/SerializableUser.cs
+++ b/Assets/HK/AutoAnt/Scripts/SaveData/Serializable/SerializableUser.cs
@@ -12,5 +12,7 @@ namespace HK.AutoAnt.SaveData.Serializables
         public SerializableWallet Wallet { get; set; }
 
         public Inventory Inventory { get; set; }
+
+        public GenerateCellEventHistory GenerateCellEventHistory { get; set; }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -11,7 +11,8 @@ namespace HK.AutoAnt.UserControllers
     [Serializable]
     public sealed class GenerateCellEventHistory
     {
-        private Dictionary<int, int> histories = new Dictionary<int, int>();
+        [SerializeField]
+        public Dictionary<int, int> histories = new Dictionary<int, int>();
 
         public void AddHistory(int cellEventRecordId)
         {

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using HK.AutoAnt.Events;
 using HK.Framework.EventSystems;
 using UnityEngine;
@@ -18,21 +19,36 @@ namespace HK.AutoAnt.UserControllers
         /// key = cellEventRecordId
         /// value = 生成した数
         /// </summary>
-        public IReadOnlyDictionary<int, int> Histories => this.histories;
-        private Dictionary<int, int> histories = new Dictionary<int, int>();
+        public IReadOnlyDictionary<int, CellEvent> Histories => this.histories;
+        private Dictionary<int, CellEvent> histories = new Dictionary<int, CellEvent>();
 
-        public void AddHistory(int cellEventRecordId)
+        public void AddHistory(int cellEventRecordId, int level)
         {
             if(!this.histories.ContainsKey(cellEventRecordId))
             {
-                this.histories.Add(cellEventRecordId, 1);
-            }
-            else
-            {
-                this.histories[cellEventRecordId]++;
+                this.histories.Add(cellEventRecordId, new CellEvent());
             }
 
+            this.histories[cellEventRecordId].Add(level);
+            Debug.Log($"recordId = {cellEventRecordId}, {string.Join(",", this.histories[cellEventRecordId].Numbers.Select(s => s.ToString()))}");
+
             Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
+        }
+
+        public class CellEvent
+        {
+            public IReadOnlyList<int> Numbers => this.numbers;
+            private List<int> numbers = new List<int>();
+
+            public void Add(int level)
+            {
+                while(this.numbers.Count - 1 < level)
+                {
+                    this.numbers.Add(0);
+                }
+
+                this.numbers[level]++;
+            }
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -24,8 +24,6 @@ namespace HK.AutoAnt.UserControllers
             {
                 this.histories[cellEventRecordId]++;
             }
-
-            Debug.Log($"celEventRecordId = {cellEventRecordId}, value = {this.histories[cellEventRecordId]}");
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -11,8 +11,13 @@ namespace HK.AutoAnt.UserControllers
     [Serializable]
     public sealed class GenerateCellEventHistory
     {
-        [SerializeField]
-        public Dictionary<int, int> histories = new Dictionary<int, int>();
+        /// <summary>
+        /// 生成履歴
+        /// key = cellEventRecordId
+        /// value = 生成した数
+        /// </summary>
+        public IReadOnlyDictionary<int, int> Histories => this.histories;
+        private Dictionary<int, int> histories = new Dictionary<int, int>();
 
         public void AddHistory(int cellEventRecordId)
         {

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using HK.AutoAnt.Events;
+using HK.Framework.EventSystems;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -29,6 +31,8 @@ namespace HK.AutoAnt.UserControllers
             {
                 this.histories[cellEventRecordId]++;
             }
+
+            Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.UserControllers
+{
+    /// <summary>
+    /// セルイベントを生成した履歴
+    /// </summary>
+    [Serializable]
+    public sealed class GenerateCellEventHistory
+    {
+        private Dictionary<int, int> histories = new Dictionary<int, int>();
+
+        public void AddHistory(int cellEventRecordId)
+        {
+            if(!this.histories.ContainsKey(cellEventRecordId))
+            {
+                this.histories.Add(cellEventRecordId, 1);
+            }
+            else
+            {
+                this.histories[cellEventRecordId]++;
+            }
+
+            Debug.Log($"celEventRecordId = {cellEventRecordId}, value = {this.histories[cellEventRecordId]}");
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -30,13 +30,19 @@ namespace HK.AutoAnt.UserControllers
             }
 
             this.histories[cellEventRecordId].Add(level);
-            Debug.Log($"recordId = {cellEventRecordId}, {string.Join(",", this.histories[cellEventRecordId].Numbers.Select(s => s.ToString()))}");
 
             Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
         }
 
         public class CellEvent
         {
+            /// <summary>
+            /// 建設した数
+            /// </summary>
+            /// <remarks>
+            /// レベルごとに建設した数を保持しています
+            /// [0]はレベル1の建設した数になります
+            /// </remarks>
             public IReadOnlyList<int> Numbers => this.numbers;
             private List<int> numbers = new List<int>();
 

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bf9bab386b6040228915a129ed3f312
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
@@ -33,6 +33,10 @@ namespace HK.AutoAnt.UserControllers
         private Town town = null;
         public Town Town => this.town;
 
+        [SerializeField]
+        private GenerateCellEventHistory generateCellEventHistory = null;
+        public GenerateCellEventHistory GenerateCellEventHistory => this.generateCellEventHistory;
+
         public SerializableUser GetSerializable()
         {
             return new SerializableUser()

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
@@ -42,8 +42,9 @@ namespace HK.AutoAnt.UserControllers
             return new SerializableUser()
             {
                 Wallet = this.Wallet.GetSerializable(),
-                Inventory = this.Inventory
-            };
+                Inventory = this.Inventory,
+                GenerateCellEventHistory = this.GenerateCellEventHistory
+        };
         }
 
         void ISavable.Initialize()
@@ -54,6 +55,7 @@ namespace HK.AutoAnt.UserControllers
                 var serializableData = saveData.Load();
                 this.wallet.Deserialize(serializableData.Wallet);
                 this.inventory = serializableData.Inventory;
+                this.generateCellEventHistory = serializableData.GenerateCellEventHistory;
             }
         }
 


### PR DESCRIPTION
## 変更点概要
- タイトルの通りで、レベルごとに建設履歴を保持するようになりました
    - 今後これを利用して生成出来るセルイベントのアンロックシステムを実装予定です
- また、デバッグ機能で生成履歴を表示するようにしました
    - `SRDebug/Options/建設履歴を表示する`
<img width="253" alt="スクリーンショット 2019-06-15 16 39 43" src="https://user-images.githubusercontent.com/5396546/59548569-33471280-8f8c-11e9-98d7-47df3b02da24.png">

- ログの例
    - `CellEventRecordId = 100000, numbers = 6,2,1`
        - 100000のレベル1を6回、レベル2を2回、レベル3を1回建設したことになります

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- やってることは単純（なにか建設したら登録するだけ）なので、かるーく目を通してもらえれば

## 特に見なくていい箇所
- そういえば`ES3Type_xxx`系クラスは自動生成されるファイルなので見なくても大丈夫 🙈 

## その他
- 🍐 
