### PR TITLE
条件を満たすと新しいセルイベントを利用出来るように

### DIFF
--- a/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+namespace ES3Types
+{
+	[ES3PropertiesAttribute("numbers")]
+	public class ES3Type_CellEvent : ES3ObjectType
+	{
+		public static ES3Type Instance = null;
+
+		public ES3Type_CellEvent() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent)){ Instance = this; }
+
+		protected override void WriteObject(object obj, ES3Writer writer)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent)obj;
+			
+			writer.WritePrivateField("numbers", instance);
+		}
+
+		protected override void ReadObject<T>(ES3Reader reader, object obj)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent)obj;
+			foreach(string propertyName in reader.Properties)
+			{
+				switch(propertyName)
+				{
+					
+					case "numbers":
+					reader.SetPrivateField("numbers", reader.Read<System.Collections.Generic.List<System.Int32>>(), instance);
+					break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+
+		protected override object ReadObject<T>(ES3Reader reader)
+		{
+			var instance = new HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent();
+			ReadObject<T>(reader, instance);
+			return instance;
+		}
+	}
+
+	public class ES3Type_CellEventArray : ES3ArrayType
+	{
+		public static ES3Type Instance;
+
+		public ES3Type_CellEventArray() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent[]), ES3Type_CellEvent.Instance)
+		{
+			Instance = this;
+		}
+	}
+}

--- a/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs.meta
+++ b/Assets/Easy Save 3/Types/ES3Type_CellEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7da1f8fdb4a4a4aacb6f099e18ed4cd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+namespace ES3Types
+{
+	[ES3PropertiesAttribute("histories")]
+	public class ES3Type_GenerateCellEventHistory : ES3ObjectType
+	{
+		public static ES3Type Instance = null;
+
+		public ES3Type_GenerateCellEventHistory() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory)){ Instance = this; }
+
+		protected override void WriteObject(object obj, ES3Writer writer)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory)obj;
+			
+			writer.WriteProperty("histories", instance.histories);
+		}
+
+		protected override void ReadObject<T>(ES3Reader reader, object obj)
+		{
+			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory)obj;
+			foreach(string propertyName in reader.Properties)
+			{
+				switch(propertyName)
+				{
+					
+					case "histories":
+						instance.histories = reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>();
+						break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+
+		protected override object ReadObject<T>(ES3Reader reader)
+		{
+			var instance = new HK.AutoAnt.UserControllers.GenerateCellEventHistory();
+			ReadObject<T>(reader, instance);
+			return instance;
+		}
+	}
+
+	public class ES3Type_GenerateCellEventHistoryArray : ES3ArrayType
+	{
+		public static ES3Type Instance;
+
+		public ES3Type_GenerateCellEventHistoryArray() : base(typeof(HK.AutoAnt.UserControllers.GenerateCellEventHistory[]), ES3Type_GenerateCellEventHistory.Instance)
+		{
+			Instance = this;
+		}
+	}
+}

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
@@ -14,7 +14,7 @@ namespace ES3Types
 		{
 			var instance = (HK.AutoAnt.UserControllers.GenerateCellEventHistory)obj;
 			
-			writer.WriteProperty("histories", instance.histories);
+			writer.WritePrivateField("histories", instance);
 		}
 
 		protected override void ReadObject<T>(ES3Reader reader, object obj)
@@ -26,8 +26,8 @@ namespace ES3Types
 				{
 					
 					case "histories":
-						instance.histories = reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>();
-						break;
+					reader.SetPrivateField("histories", reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>(), instance);
+					break;
 					default:
 						reader.Skip();
 						break;

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs
@@ -26,7 +26,7 @@ namespace ES3Types
 				{
 					
 					case "histories":
-					reader.SetPrivateField("histories", reader.Read<System.Collections.Generic.Dictionary<System.Int32, System.Int32>>(), instance);
+					reader.SetPrivateField("histories", reader.Read<System.Collections.Generic.Dictionary<System.Int32, HK.AutoAnt.UserControllers.GenerateCellEventHistory.CellEvent>>(), instance);
 					break;
 					default:
 						reader.Skip();

--- a/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs.meta
+++ b/Assets/Easy Save 3/Types/ES3Type_GenerateCellEventHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cbd73e7fbc1249f99680464d3c535be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Easy Save 3/Types/ES3Type_SerializableUser.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_SerializableUser.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace ES3Types
 {
-	[ES3PropertiesAttribute("Wallet", "Inventory")]
+	[ES3PropertiesAttribute("Wallet", "Inventory", "GenerateCellEventHistory")]
 	public class ES3Type_SerializableUser : ES3ObjectType
 	{
 		public static ES3Type Instance = null;
@@ -16,6 +16,7 @@ namespace ES3Types
 			
 			writer.WriteProperty("Wallet", instance.Wallet, ES3Type_SerializableWallet.Instance);
 			writer.WriteProperty("Inventory", instance.Inventory, ES3Type_Inventory.Instance);
+			writer.WriteProperty("GenerateCellEventHistory", instance.GenerateCellEventHistory, ES3Type_GenerateCellEventHistory.Instance);
 		}
 
 		protected override void ReadObject<T>(ES3Reader reader, object obj)
@@ -31,6 +32,9 @@ namespace ES3Types
 						break;
 					case "Inventory":
 						instance.Inventory = reader.Read<HK.AutoAnt.UserControllers.Inventory>(ES3Type_Inventory.Instance);
+						break;
+					case "GenerateCellEventHistory":
+						instance.GenerateCellEventHistory = reader.Read<HK.AutoAnt.UserControllers.GenerateCellEventHistory>(ES3Type_GenerateCellEventHistory.Instance);
 						break;
 					default:
 						reader.Skip();

--- a/Assets/Easy Save 3/Types/ES3Type_SerializableUser.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_SerializableUser.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace ES3Types
 {
-	[ES3PropertiesAttribute("Wallet", "Inventory", "GenerateCellEventHistory")]
+	[ES3PropertiesAttribute("Wallet", "Inventory", "GenerateCellEventHistory", "UnlockCellEvents")]
 	public class ES3Type_SerializableUser : ES3ObjectType
 	{
 		public static ES3Type Instance = null;
@@ -17,6 +17,7 @@ namespace ES3Types
 			writer.WriteProperty("Wallet", instance.Wallet, ES3Type_SerializableWallet.Instance);
 			writer.WriteProperty("Inventory", instance.Inventory, ES3Type_Inventory.Instance);
 			writer.WriteProperty("GenerateCellEventHistory", instance.GenerateCellEventHistory, ES3Type_GenerateCellEventHistory.Instance);
+			writer.WriteProperty("UnlockCellEvents", instance.UnlockCellEvents, ES3Type_UnlockCellEvents.Instance);
 		}
 
 		protected override void ReadObject<T>(ES3Reader reader, object obj)
@@ -35,6 +36,9 @@ namespace ES3Types
 						break;
 					case "GenerateCellEventHistory":
 						instance.GenerateCellEventHistory = reader.Read<HK.AutoAnt.UserControllers.GenerateCellEventHistory>(ES3Type_GenerateCellEventHistory.Instance);
+						break;
+					case "UnlockCellEvents":
+						instance.UnlockCellEvents = reader.Read<HK.AutoAnt.UserControllers.UnlockCellEvents>(ES3Type_UnlockCellEvents.Instance);
 						break;
 					default:
 						reader.Skip();

--- a/Assets/Easy Save 3/Types/ES3Type_UnlockCellEvents.cs
+++ b/Assets/Easy Save 3/Types/ES3Type_UnlockCellEvents.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+namespace ES3Types
+{
+	[ES3PropertiesAttribute("cellEvents")]
+	public class ES3Type_UnlockCellEvents : ES3ObjectType
+	{
+		public static ES3Type Instance = null;
+
+		public ES3Type_UnlockCellEvents() : base(typeof(HK.AutoAnt.UserControllers.UnlockCellEvents)){ Instance = this; }
+
+		protected override void WriteObject(object obj, ES3Writer writer)
+		{
+			var instance = (HK.AutoAnt.UserControllers.UnlockCellEvents)obj;
+			
+			writer.WritePrivateField("cellEvents", instance);
+		}
+
+		protected override void ReadObject<T>(ES3Reader reader, object obj)
+		{
+			var instance = (HK.AutoAnt.UserControllers.UnlockCellEvents)obj;
+			foreach(string propertyName in reader.Properties)
+			{
+				switch(propertyName)
+				{
+					
+					case "cellEvents":
+					reader.SetPrivateField("cellEvents", reader.Read<System.Collections.Generic.List<System.Int32>>(), instance);
+					break;
+					default:
+						reader.Skip();
+						break;
+				}
+			}
+		}
+
+		protected override object ReadObject<T>(ES3Reader reader)
+		{
+			var instance = new HK.AutoAnt.UserControllers.UnlockCellEvents();
+			ReadObject<T>(reader, instance);
+			return instance;
+		}
+	}
+
+	public class ES3Type_UnlockCellEventsArray : ES3ArrayType
+	{
+		public static ES3Type Instance;
+
+		public ES3Type_UnlockCellEventsArray() : base(typeof(HK.AutoAnt.UserControllers.UnlockCellEvents[]), ES3Type_UnlockCellEvents.Instance)
+		{
+			Instance = this;
+		}
+	}
+}

--- a/Assets/Easy Save 3/Types/ES3Type_UnlockCellEvents.cs.meta
+++ b/Assets/Easy Save 3/Types/ES3Type_UnlockCellEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6b614d53b6ee41d4bf7f91c4773543f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/DataSources/Database/MasterData.asset
+++ b/Assets/HK/AutoAnt/DataSources/Database/MasterData.asset
@@ -20,3 +20,4 @@ MonoBehaviour:
     type: 2}
   facilityLevelParameter: {fileID: 11400000, guid: 5e64f02039ca648e88608647a4d8176f,
     type: 2}
+  unlockCellEvent: {fileID: 11400000, guid: 205009221d8ff40df9aba6922d9ba38c, type: 2}

--- a/Assets/HK/AutoAnt/DataSources/Database/UnlockCellEvent.asset
+++ b/Assets/HK/AutoAnt/DataSources/Database/UnlockCellEvent.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18794ff84dd1d47c0a4eecb74c2ca6b7, type: 3}
+  m_Name: UnlockCellEvent
+  m_EditorClassIdentifier: 
+  records:
+  - id: 100000
+    unlockCellEventRecordId: 100000
+    needCellEvents:
+    - CellEventRecordId: 100000
+      Level: 1
+      Number: 3

--- a/Assets/HK/AutoAnt/DataSources/Database/UnlockCellEvent.asset
+++ b/Assets/HK/AutoAnt/DataSources/Database/UnlockCellEvent.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: UnlockCellEvent
   m_EditorClassIdentifier: 
   records:
-  - id: 100000
-    unlockCellEventRecordId: 100000
+  - id: 1
+    unlockCellEventRecordId: 101000
     needCellEvents:
     - CellEventRecordId: 100000
       Level: 1

--- a/Assets/HK/AutoAnt/DataSources/Database/UnlockCellEvent.asset.meta
+++ b/Assets/HK/AutoAnt/DataSources/Database/UnlockCellEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 205009221d8ff40df9aba6922d9ba38c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Editor/QuickSheetSettings/UnlockCellEvent.asset
+++ b/Assets/HK/AutoAnt/Editor/QuickSheetSettings/UnlockCellEvent.asset
@@ -1,0 +1,34 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bdb4931813a361148a6651be452ff88e, type: 3}
+  m_Name: UnlockCellEvent
+  m_EditorClassIdentifier: 
+  templatePath: HK/AutoAnt/Editor/QuickSheetTemplates/Id
+  scriptFilePath: HK/AutoAnt/Scripts/Database/Runtime
+  editorScriptFilePath: HK/AutoAnt/Scripts/Database/Editor
+  sheetName: AutoAnt
+  workSheetName: UnlockCellEvent
+  scriptableObjectName: MasterDataUnlockCellEvent
+  columnHeaderList:
+  - type: 3
+    name: Id
+    isEnable: 0
+    isArray: 0
+  - type: 3
+    name: UnlockCellEventRecordId
+    isEnable: 0
+    isArray: 0
+  - type: 1
+    name: NeedCellEvent
+    isEnable: 0
+    isArray: 0
+  AccessCode: 

--- a/Assets/HK/AutoAnt/Editor/QuickSheetSettings/UnlockCellEvent.asset.meta
+++ b/Assets/HK/AutoAnt/Editor/QuickSheetSettings/UnlockCellEvent.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db20ab99ad70341cebe14c3add2eb8aa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -52,7 +52,7 @@ namespace HK.AutoAnt.CellControllers
             cellEventInstance.Initialize(cell.Position, this.gameSystem, isInitializingGame);
             cellMapper.Add(cellEventInstance);
 
-            this.gameSystem.User.GenerateCellEventHistory.AddHistory(cellEventRecordId);
+            this.gameSystem.User.GenerateCellEventHistory.AddHistory(cellEventRecordId, 0);
         }
 
         public void GenerateOnDeserialize(CellEvent instance)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -51,6 +51,8 @@ namespace HK.AutoAnt.CellControllers
             cellEventInstance.name = cellEventRecord.EventData.name;
             cellEventInstance.Initialize(cell.Position, this.gameSystem, isInitializingGame);
             cellMapper.Add(cellEventInstance);
+
+            this.gameSystem.User.GenerateCellEventHistory.AddHistory(cellEventRecordId);
         }
 
         public void GenerateOnDeserialize(CellEvent instance)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Housing.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Housing.cs
@@ -79,6 +79,7 @@ namespace HK.AutoAnt.CellControllers.Events
         {
             this.LevelUp(this.gameSystem);
             this.levelParameter = this.gameSystem.MasterData.HousingLevelParameter.Records.Get(this.Id, this.Level);
+            this.gameSystem.User.GenerateCellEventHistory.AddHistory(this.Id, this.Level - 1);
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/Database/Editor/UnlockCellEventEditor.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/Editor/UnlockCellEventEditor.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+using GDataDB;
+using GDataDB.Linq;
+
+using UnityQuickSheet;
+
+namespace HK.AutoAnt.Database.SpreadSheetData
+{
+    ///
+    /// !!! Machine generated code !!!
+    ///
+    [CustomEditor(typeof(MasterDataUnlockCellEvent))]
+    public class UnlockCellEventEditor : BaseGoogleEditor<MasterDataUnlockCellEvent>
+    {
+        private const string WorkSheetName = "UnlockCellEvent";
+
+        private const string SpreadSheetName = "AutoAnt";
+
+        public override bool Load()
+        {        
+            var targetData = target as MasterDataUnlockCellEvent;
+            var client = new DatabaseClient("", "");
+            var error = string.Empty;
+            var db = client.GetDatabase(SpreadSheetName, ref error);	
+            var table = db.GetTable<UnlockCellEventData>(WorkSheetName) ?? db.CreateTable<UnlockCellEventData>(WorkSheetName);
+            var myDataList = new List<MasterDataUnlockCellEvent.Record>();
+            var all = table.FindAll();
+
+            foreach(var element in all)
+            {
+                var data = new UnlockCellEventData();
+                data = Cloner.DeepCopy<UnlockCellEventData>(element.Element);
+                myDataList.Add(new MasterDataUnlockCellEvent.Record(data));
+            }
+                    
+            targetData.Records = myDataList.ToArray();
+            
+            EditorUtility.SetDirty(targetData);
+            AssetDatabase.SaveAssets();
+            
+            return true;
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Database/Editor/UnlockCellEventEditor.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Database/Editor/UnlockCellEventEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0eabfcc89eea94a8d86f2f0f7c432b98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/Database/MasterData.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/MasterData.cs
@@ -33,5 +33,9 @@ namespace HK.AutoAnt.Database
         [SerializeField]
         private MasterDataFacilityLevelParameter facilityLevelParameter = null;
         public MasterDataFacilityLevelParameter FacilityLevelParameter => this.facilityLevelParameter;
+
+        [SerializeField]
+        private MasterDataUnlockCellEvent unlockCellEvent = null;
+        public MasterDataUnlockCellEvent UnlockCellEvent => this.unlockCellEvent;
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/Database/MasterDataUnlockCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/MasterDataUnlockCellEvent.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using HK.Framework.Text;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace HK.AutoAnt.Database
+{
+    /// <summary>
+    /// アンロック出来るセルイベントのマスターデータ
+    /// </summary>
+    [CreateAssetMenu(menuName = "AutoAnt/Database/UnlockCellEvent")]
+    public sealed class MasterDataUnlockCellEvent : MasterDataBase<MasterDataUnlockCellEvent.Record>
+    {
+        [Serializable]
+        public class Record : IRecord
+        {
+            [SerializeField]
+            private int id = 0;
+            public int Id => this.id;
+
+            /// <summary>
+            /// アンロック出来るセルイベントのレコードID
+            /// </summary>
+            [SerializeField]
+            private int unlockCellEventRecordId = 0;
+            public int UnlockCellEventRecordId => this.unlockCellEventRecordId;
+
+            [SerializeField]
+            private NeedCellEvent[] needCellEvents = null;
+            public NeedCellEvent[] NeedCellEvents => this.needCellEvents;
+
+#if UNITY_EDITOR
+            public Record(SpreadSheetData.UnlockCellEventData data)
+            {
+                this.id = data.Id;
+                this.unlockCellEventRecordId = data.Unlockcelleventrecordid;
+                this.needCellEvents = JsonUtility.FromJson<NeedCellEvent.Json>(data.Needcellevent).NeedCellEvent;
+            }
+#endif
+
+            [Serializable]
+            public class NeedCellEvent
+            {
+                public int CellEventRecordId;
+                public int Level;
+                public int Number;
+
+                [Serializable]
+                public class Json
+                {
+                    public NeedCellEvent[] NeedCellEvent;
+                }
+            }
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Database/MasterDataUnlockCellEvent.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Database/MasterDataUnlockCellEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 18794ff84dd1d47c0a4eecb74c2ca6b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/Database/Runtime/UnlockCellEventData.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/Runtime/UnlockCellEventData.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using System.Collections;
+using HK.AutoAnt.Constants;
+
+namespace HK.AutoAnt.Database.SpreadSheetData
+{
+    ///
+    /// !!! Machine generated code !!!
+    /// !!! DO NOT CHANGE Tabs to Spaces !!!
+    ///
+    [System.Serializable]
+    public class UnlockCellEventData : IRecord
+    {
+[SerializeField]
+int id;
+public int Id { get {return id; } set { id = value;} }
+
+[SerializeField]
+int unlockcelleventrecordid;
+public int Unlockcelleventrecordid { get {return unlockcelleventrecordid; } set { unlockcelleventrecordid = value;} }
+
+[SerializeField]
+string needcellevent;
+public string Needcellevent { get {return needcellevent; } set { needcellevent = value;} }
+
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Database/Runtime/UnlockCellEventData.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Database/Runtime/UnlockCellEventData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f3aa2808644b48a083ab838173e2e7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Linq;
 using HK.AutoAnt.Systems;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -33,6 +34,16 @@ public partial class SROptions
         foreach(var record in masterData.Records)
         {
             GameSystem.Instance.User.Inventory.AddItem(record, 10);
+        }
+    }
+
+    [Category(UserCategory)]
+    [DisplayName("建設履歴を表示する")]
+    public void PrintGenerateCellEventHistories()
+    {
+        foreach(var h in GameSystem.Instance.User.GenerateCellEventHistory.Histories)
+        {
+            Debug.Log($"CellEventRecordId = {h.Key}, numbers = {string.Join(",", h.Value.Numbers.Select(n => n.ToString()))}");
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
@@ -41,10 +41,17 @@ public partial class SROptions
     [DisplayName("建設履歴を表示する")]
     public void PrintGenerateCellEventHistories()
     {
-        foreach(var h in GameSystem.Instance.User.GenerateCellEventHistory.Histories)
+        foreach (var h in GameSystem.Instance.User.GenerateCellEventHistory.Histories)
         {
             Debug.Log($"CellEventRecordId = {h.Key}, numbers = {string.Join(",", h.Value.Numbers.Select(n => n.ToString()))}");
         }
+    }
+
+    [Category(UserCategory)]
+    [DisplayName("アンロックを表示する")]
+    public void PrintUnlockCellEvent()
+    {
+        Debug.Log($"{string.Join(",", GameSystem.Instance.User.UnlockCellEvents.CellEvents.Select(x => x.ToString()))}");
     }
 }
 #endif

--- a/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs
@@ -1,0 +1,24 @@
+﻿using HK.AutoAnt.Database;
+using HK.AutoAnt.UserControllers;
+using HK.Framework.EventSystems;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.Events
+{
+    /// <summary>
+    /// セルイベント生成の履歴が追加された際のイベント
+    /// </summary>
+    public sealed class AddedGenerateCellEventHistory : Message<AddedGenerateCellEventHistory, GenerateCellEventHistory, int>
+    {
+        /// <summary>
+        /// 追加された<see cref="GenerateCellEventHistory"/>
+        /// </summary>
+        public GenerateCellEventHistory GenerateCellEventHistory => this.param1;
+
+        /// <summary>
+        /// 追加されたセルイベントのレコードID
+        /// </summary>
+        public int CellEventRecordId => this.param2;
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Events/AddedGenerateCellEventHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56eeccbaed47a4a6baa1ebc654d95dad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/Events/UnlockedCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/Events/UnlockedCellEvent.cs
@@ -1,0 +1,17 @@
+﻿using HK.Framework.EventSystems;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.Events
+{
+    /// <summary>
+    /// 利用可能なセルイベントがアンロックされた際のイベント
+    /// </summary>
+    public sealed class UnlockedCellEvent : Message<UnlockedCellEvent, int>
+    {
+        /// <summary>
+        /// アンロックされたセルイベントのレコードID
+        /// </summary>
+        public int CellEventRecordId => this.param1;
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Events/UnlockedCellEvent.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Events/UnlockedCellEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76bd1aa1402f04f7e92efc0908207f3c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/SaveData/Serializable/SerializableUser.cs
+++ b/Assets/HK/AutoAnt/Scripts/SaveData/Serializable/SerializableUser.cs
@@ -14,5 +14,7 @@ namespace HK.AutoAnt.SaveData.Serializables
         public Inventory Inventory { get; set; }
 
         public GenerateCellEventHistory GenerateCellEventHistory { get; set; }
+
+        public UnlockCellEvents UnlockCellEvents { get; set; }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/SaveData/Serializable/SerializableUser.cs
+++ b/Assets/HK/AutoAnt/Scripts/SaveData/Serializable/SerializableUser.cs
@@ -12,5 +12,7 @@ namespace HK.AutoAnt.SaveData.Serializables
         public SerializableWallet Wallet { get; set; }
 
         public Inventory Inventory { get; set; }
+
+        public GenerateCellEventHistory GenerateCellEventHistory { get; set; }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -11,7 +11,8 @@ namespace HK.AutoAnt.UserControllers
     [Serializable]
     public sealed class GenerateCellEventHistory
     {
-        private Dictionary<int, int> histories = new Dictionary<int, int>();
+        [SerializeField]
+        public Dictionary<int, int> histories = new Dictionary<int, int>();
 
         public void AddHistory(int cellEventRecordId)
         {

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using HK.AutoAnt.Events;
 using HK.Framework.EventSystems;
 using UnityEngine;
@@ -18,21 +19,36 @@ namespace HK.AutoAnt.UserControllers
         /// key = cellEventRecordId
         /// value = 生成した数
         /// </summary>
-        public IReadOnlyDictionary<int, int> Histories => this.histories;
-        private Dictionary<int, int> histories = new Dictionary<int, int>();
+        public IReadOnlyDictionary<int, CellEvent> Histories => this.histories;
+        private Dictionary<int, CellEvent> histories = new Dictionary<int, CellEvent>();
 
-        public void AddHistory(int cellEventRecordId)
+        public void AddHistory(int cellEventRecordId, int level)
         {
             if(!this.histories.ContainsKey(cellEventRecordId))
             {
-                this.histories.Add(cellEventRecordId, 1);
-            }
-            else
-            {
-                this.histories[cellEventRecordId]++;
+                this.histories.Add(cellEventRecordId, new CellEvent());
             }
 
+            this.histories[cellEventRecordId].Add(level);
+            Debug.Log($"recordId = {cellEventRecordId}, {string.Join(",", this.histories[cellEventRecordId].Numbers.Select(s => s.ToString()))}");
+
             Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
+        }
+
+        public class CellEvent
+        {
+            public IReadOnlyList<int> Numbers => this.numbers;
+            private List<int> numbers = new List<int>();
+
+            public void Add(int level)
+            {
+                while(this.numbers.Count - 1 < level)
+                {
+                    this.numbers.Add(0);
+                }
+
+                this.numbers[level]++;
+            }
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -35,10 +35,14 @@ namespace HK.AutoAnt.UserControllers
             Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
         }
 
+        /// <summary>
+        /// アンロック可能か返す
+        /// </summary>
         public bool IsEnough(MasterDataUnlockCellEvent.Record.NeedCellEvent[] needs)
         {
             foreach (var n in needs)
             {
+                // そもそも生成履歴に存在しない場合はアンロック出来ない
                 if (!histories.ContainsKey(n.CellEventRecordId))
                 {
                     return false;
@@ -75,8 +79,12 @@ namespace HK.AutoAnt.UserControllers
                 this.numbers[level]++;
             }
 
+            /// <summary>
+            /// アンロック可能か返す
+            /// </summary>
             public bool IsEnough(MasterDataUnlockCellEvent.Record.NeedCellEvent need)
             {
+                // 指定されたレベルを一度も生成したことが無い場合はアンロック出来ない
                 if(this.numbers.Count < need.Level)
                 {
                     return false;

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -24,8 +24,6 @@ namespace HK.AutoAnt.UserControllers
             {
                 this.histories[cellEventRecordId]++;
             }
-
-            Debug.Log($"celEventRecordId = {cellEventRecordId}, value = {this.histories[cellEventRecordId]}");
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -11,8 +11,13 @@ namespace HK.AutoAnt.UserControllers
     [Serializable]
     public sealed class GenerateCellEventHistory
     {
-        [SerializeField]
-        public Dictionary<int, int> histories = new Dictionary<int, int>();
+        /// <summary>
+        /// 生成履歴
+        /// key = cellEventRecordId
+        /// value = 生成した数
+        /// </summary>
+        public IReadOnlyDictionary<int, int> Histories => this.histories;
+        private Dictionary<int, int> histories = new Dictionary<int, int>();
 
         public void AddHistory(int cellEventRecordId)
         {

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using HK.AutoAnt.Events;
+using HK.Framework.EventSystems;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -29,6 +31,8 @@ namespace HK.AutoAnt.UserControllers
             {
                 this.histories[cellEventRecordId]++;
             }
+
+            Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.UserControllers
+{
+    /// <summary>
+    /// セルイベントを生成した履歴
+    /// </summary>
+    [Serializable]
+    public sealed class GenerateCellEventHistory
+    {
+        private Dictionary<int, int> histories = new Dictionary<int, int>();
+
+        public void AddHistory(int cellEventRecordId)
+        {
+            if(!this.histories.ContainsKey(cellEventRecordId))
+            {
+                this.histories.Add(cellEventRecordId, 1);
+            }
+            else
+            {
+                this.histories[cellEventRecordId]++;
+            }
+
+            Debug.Log($"celEventRecordId = {cellEventRecordId}, value = {this.histories[cellEventRecordId]}");
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using HK.AutoAnt.Database;
 using HK.AutoAnt.Events;
 using HK.Framework.EventSystems;
 using UnityEngine;
@@ -34,6 +35,24 @@ namespace HK.AutoAnt.UserControllers
             Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
         }
 
+        public bool IsEnough(MasterDataUnlockCellEvent.Record.NeedCellEvent[] needs)
+        {
+            foreach (var n in needs)
+            {
+                if (!histories.ContainsKey(n.CellEventRecordId))
+                {
+                    return false;
+                }
+
+                if(!histories[n.CellEventRecordId].IsEnough(n))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public class CellEvent
         {
             /// <summary>
@@ -54,6 +73,16 @@ namespace HK.AutoAnt.UserControllers
                 }
 
                 this.numbers[level]++;
+            }
+
+            public bool IsEnough(MasterDataUnlockCellEvent.Record.NeedCellEvent need)
+            {
+                if(this.numbers.Count < need.Level)
+                {
+                    return false;
+                }
+
+                return this.numbers[need.Level - 1] >= need.Number;
             }
         }
     }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs
@@ -30,13 +30,19 @@ namespace HK.AutoAnt.UserControllers
             }
 
             this.histories[cellEventRecordId].Add(level);
-            Debug.Log($"recordId = {cellEventRecordId}, {string.Join(",", this.histories[cellEventRecordId].Numbers.Select(s => s.ToString()))}");
 
             Broker.Global.Publish(AddedGenerateCellEventHistory.Get(this, cellEventRecordId));
         }
 
         public class CellEvent
         {
+            /// <summary>
+            /// 建設した数
+            /// </summary>
+            /// <remarks>
+            /// レベルごとに建設した数を保持しています
+            /// [0]はレベル1の建設した数になります
+            /// </remarks>
             public IReadOnlyList<int> Numbers => this.numbers;
             private List<int> numbers = new List<int>();
 

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/GenerateCellEventHistory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bf9bab386b6040228915a129ed3f312
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs
@@ -40,9 +40,9 @@ namespace HK.AutoAnt.UserControllers
                         if(histories.IsEnough(i.NeedCellEvents))
                         {
                             _this.cellEvents.Add(i.UnlockCellEventRecordId);
+                            Broker.Global.Publish(UnlockedCellEvent.Get(i.UnlockCellEventRecordId));
                         }
                     }
-
                 })
                 .AddTo(gameSystem);
         }

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs
@@ -40,7 +40,6 @@ namespace HK.AutoAnt.UserControllers
                         if(histories.IsEnough(i.NeedCellEvents))
                         {
                             _this.cellEvents.Add(i.UnlockCellEventRecordId);
-                            Debug.Log($"Unlock! CellEventRecordId = {i.UnlockCellEventRecordId}");
                         }
                     }
 

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using HK.AutoAnt.Events;
+using HK.Framework.EventSystems;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.UserControllers
+{
+    /// <summary>
+    /// 生成可能なセルイベントを管理するクラス
+    /// </summary>
+    public sealed class UnlockCellEvents
+    {
+        /// <summary>
+        /// 生成可能なセルイベントリスト
+        /// </summary>
+        public IReadOnlyList<int> CellEvents => this.cellEvents;
+        private List<int> cellEvents = new List<int>();
+
+        /// <summary>
+        /// 生成履歴の監視を開始する
+        /// </summary>
+        public void StartObserve()
+        {
+            // Broker.Global.Receive<AddedGenerateCellEventHistory>()
+            //     .SubscribeWithState()
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/UnlockCellEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9afa046eff61c44f88aefe88e8ae925e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
@@ -1,6 +1,7 @@
 ﻿using HK.AutoAnt.GameControllers;
 using HK.AutoAnt.SaveData;
 using HK.AutoAnt.SaveData.Serializables;
+using HK.AutoAnt.Systems;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -37,6 +38,10 @@ namespace HK.AutoAnt.UserControllers
         private GenerateCellEventHistory generateCellEventHistory = null;
         public GenerateCellEventHistory GenerateCellEventHistory => this.generateCellEventHistory;
 
+        [SerializeField]
+        private UnlockCellEvents unlockCellEvents = null;
+        public UnlockCellEvents UnlockCellEvents => this.unlockCellEvents;
+
         public SerializableUser GetSerializable()
         {
             return new SerializableUser()
@@ -44,7 +49,7 @@ namespace HK.AutoAnt.UserControllers
                 Wallet = this.Wallet.GetSerializable(),
                 Inventory = this.Inventory,
                 GenerateCellEventHistory = this.GenerateCellEventHistory
-        };
+            };
         }
 
         void ISavable.Initialize()
@@ -57,6 +62,8 @@ namespace HK.AutoAnt.UserControllers
                 this.inventory = serializableData.Inventory;
                 this.generateCellEventHistory = serializableData.GenerateCellEventHistory;
             }
+
+            this.unlockCellEvents.StartObserve(GameSystem.Instance);
         }
 
         void ISavable.Save()

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
@@ -48,7 +48,8 @@ namespace HK.AutoAnt.UserControllers
             {
                 Wallet = this.Wallet.GetSerializable(),
                 Inventory = this.Inventory,
-                GenerateCellEventHistory = this.GenerateCellEventHistory
+                GenerateCellEventHistory = this.GenerateCellEventHistory,
+                UnlockCellEvents = this.UnlockCellEvents
             };
         }
 
@@ -61,6 +62,7 @@ namespace HK.AutoAnt.UserControllers
                 this.wallet.Deserialize(serializableData.Wallet);
                 this.inventory = serializableData.Inventory;
                 this.generateCellEventHistory = serializableData.GenerateCellEventHistory;
+                this.unlockCellEvents = serializableData.UnlockCellEvents;
             }
 
             this.unlockCellEvents.StartObserve(GameSystem.Instance);

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
@@ -33,6 +33,10 @@ namespace HK.AutoAnt.UserControllers
         private Town town = null;
         public Town Town => this.town;
 
+        [SerializeField]
+        private GenerateCellEventHistory generateCellEventHistory = null;
+        public GenerateCellEventHistory GenerateCellEventHistory => this.generateCellEventHistory;
+
         public SerializableUser GetSerializable()
         {
             return new SerializableUser()

--- a/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
+++ b/Assets/HK/AutoAnt/Scripts/UserControllers/User.cs
@@ -42,8 +42,9 @@ namespace HK.AutoAnt.UserControllers
             return new SerializableUser()
             {
                 Wallet = this.Wallet.GetSerializable(),
-                Inventory = this.Inventory
-            };
+                Inventory = this.Inventory,
+                GenerateCellEventHistory = this.GenerateCellEventHistory
+        };
         }
 
         void ISavable.Initialize()
@@ -54,6 +55,7 @@ namespace HK.AutoAnt.UserControllers
                 var serializableData = saveData.Load();
                 this.wallet.Deserialize(serializableData.Wallet);
                 this.inventory = serializableData.Inventory;
+                this.generateCellEventHistory = serializableData.GenerateCellEventHistory;
             }
         }
 


### PR DESCRIPTION
## 変更点概要
- タイトルの通り
    - 現段階では指定したセルイベントのレベルをn個生成したらアンロックするようになっています
    - アンロックのマスターデータは[UnlockCellEventシート](https://docs.google.com/spreadsheets/d/1n27bC7lfRZxsHvPN3UghRA98E7jeVFsAdXInsZh9QEo/edit#gid=1980580499)にあります
- また、現在のアンロック情報をログで表示するデバッグも追加しました
    - `SRDebug/Options/アンロックを表示する`
<img width="252" alt="スクリーンショット 2019-06-15 17 34 35" src="https://user-images.githubusercontent.com/5396546/59549120-00a11800-8f94-11e9-9350-78cdf31e03b9.png">


## 依存するPR（先にマージする必要のあるPR）
- #32 

## 特に見てほしい箇所
- 今はとりあえず`100000`を3個生成すると`101000`がアンロックされます

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
