### PR TITLE
モバイルだとタップしても反応が無かった問題を修正

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/Input/Input.cs
+++ b/Assets/HK/AutoAnt/Scripts/Input/Input.cs
@@ -16,8 +16,11 @@ namespace HK.AutoAnt.InputControllers
             {
                 if(module == null)
                 {
-                    // TODO: プラットフォーム対応
+#if UNITY_ANDROID || UNITY_IOS
+                    module = new Mobile();
+#else
                     module = new Standalone();
+#endif
                 }
 
                 return module;

--- a/Assets/HK/AutoAnt/Scripts/Input/Modules/Mobile.cs
+++ b/Assets/HK/AutoAnt/Scripts/Input/Modules/Mobile.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using UniRx;
+using UnityEngine;
+using UnityEngine.Assertions;
+using UnityEngine.EventSystems;
+
+namespace HK.AutoAnt.InputControllers.Modules
+{
+    /// <summary>
+    /// モバイルの入力制御クラス
+    /// </summary>
+    public sealed class Mobile : IInputModule
+    {
+        public IMessageBroker Broker => HK.Framework.EventSystems.Broker.Global;
+
+        public int MainPointerId => -0;
+
+        public Mobile()
+        {
+            Observable.EveryUpdate()
+                .SubscribeWithState(this, (_, _this) =>
+                {
+                    _this.UpdateScroll();
+                });
+        }
+
+        public IObservable<Events.Click> ClickAsObservable()
+        {
+            return Broker.Receive<Events.Click>();
+        }
+
+        public IObservable<Events.ClickDown> ClickDownAsObservable()
+        {
+            return Broker.Receive<Events.ClickDown>();
+        }
+
+        public IObservable<Events.ClickUp> ClickUpAsObservable()
+        {
+            return Broker.Receive<Events.ClickUp>();
+        }
+
+        public IObservable<Events.Drag> DragAsObservable()
+        {
+            return Broker.Receive<Events.Drag>();
+        }
+
+        public IObservable<Events.Scroll> ScrollAsObservable()
+        {
+            return Broker.Receive<Events.Scroll>();
+        }
+
+        private void UpdateScroll()
+        {
+            var amount = UnityEngine.Input.GetAxis("Mouse ScrollWheel");
+            if (amount != 0f)
+            {
+                Input.Current.Broker.Publish(Events.Scroll.Get(Events.ScrollData.Get(amount)));
+            }
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            Input.Current.Broker.Publish(Events.Drag.Get(Events.DragData.Get(eventData.delta)));
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (eventData.dragging)
+            {
+                return;
+            }
+
+            Input.Current.Broker.Publish(Events.ClickUp.Get(Events.ClickData.Get(eventData.pointerId, eventData.position)));
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            Input.Current.Broker.Publish(Events.ClickDown.Get(Events.ClickData.Get(eventData.pointerId, eventData.position)));
+        }
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Input/Modules/Mobile.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Input/Modules/Mobile.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2070dc26c9de54c6e999f6827c266eee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/Input/Modules/Standalone.cs
+++ b/Assets/HK/AutoAnt/Scripts/Input/Modules/Standalone.cs
@@ -70,12 +70,12 @@ namespace HK.AutoAnt.InputControllers.Modules
                 return;
             }
 
-            Input.Current.Broker.Publish(Events.ClickUp.Get(Events.ClickData.Get(eventData.pointerId, UnityEngine.Input.mousePosition)));
+            Input.Current.Broker.Publish(Events.ClickUp.Get(Events.ClickData.Get(eventData.pointerId, eventData.position)));
         }
 
         public void OnPointerDown(PointerEventData eventData)
         {
-            Input.Current.Broker.Publish(Events.ClickDown.Get(Events.ClickData.Get(eventData.pointerId, UnityEngine.Input.mousePosition)));
+            Input.Current.Broker.Publish(Events.ClickDown.Get(Events.ClickData.Get(eventData.pointerId, eventData.position)));
         }
     }
 }


### PR DESCRIPTION
## 変更点概要
- スタンドアロンだとpointerIdが`-1`だけどモバイルだと`0`となっておりタップ処理にミスがあった

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 本当にタップ出来るか？

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 