### PR TITLE
カメラの移動をワールド座標に変換してから行うように

### DIFF
--- a/Assets/HK/AutoAnt/Prefabs/Cameraman.prefab
+++ b/Assets/HK/AutoAnt/Prefabs/Cameraman.prefab
@@ -24,7 +24,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 194068859128775545}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -10}
+  m_LocalPosition: {x: 0, y: 0, z: -100}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2015222507592039605}

--- a/Assets/HK/AutoAnt/Scripts/CameraControllers/Cameraman.cs
+++ b/Assets/HK/AutoAnt/Scripts/CameraControllers/Cameraman.cs
@@ -94,8 +94,9 @@ namespace HK.AutoAnt.CameraControllers
             var t = this.Camera.transform;
             var forward = Vector3.Scale(t.forward, new Vector3(1.0f, 0.0f, 1.0f)).normalized;
             var right = t.right;
+            var forwardRate = 1.0f + (1.0f - (t.rotation.eulerAngles.x / 90.0f));
 
-            return (forward * forwardVelocity) + (right * rightVelocity);
+            return (forward * forwardVelocity * forwardRate) + (right * rightVelocity);
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/CameraControllers/GameCameraController.cs
+++ b/Assets/HK/AutoAnt/Scripts/CameraControllers/GameCameraController.cs
@@ -9,10 +9,34 @@ namespace HK.AutoAnt.CameraControllers
     /// </summary>
     public sealed class GameCameraController : MonoBehaviour
     {
-        public void Move(float forwardVelocity, float rightVelocity)
+        void Update()
+        {
+            float vector = 0.1f;
+            if (Input.GetKey(KeyCode.W))
+            {
+                this.Move(new Vector2(0.0f, vector));
+            }
+            if (Input.GetKey(KeyCode.S))
+            {
+                this.Move(new Vector2(0.0f, -vector));
+            }
+            if (Input.GetKey(KeyCode.A))
+            {
+                this.Move(new Vector2(-vector, 0.0f));
+            }
+            if (Input.GetKey(KeyCode.D))
+            {
+                this.Move(new Vector2(vector, 0.0f));
+            }
+        }
+        public void Move(Vector2 deltaPosition)
         {
             var cameraman = GameSystem.Instance.Cameraman;
-            cameraman.Position -= cameraman.ToFirstPersonVector(forwardVelocity, rightVelocity);
+            var camera = cameraman.Camera;
+            var size = camera.orthographicSize;
+            var ratioX = size * 2.0f / Screen.height;
+            var ratioY = size * 2.0f / Screen.width * camera.aspect;
+            cameraman.Position -= cameraman.ToFirstPersonVector(deltaPosition.y * ratioY, deltaPosition.x * ratioX);
         }
 
         public void Zoom(float velocity)

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/DragToMoveCamera.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/DragToMoveCamera.cs
@@ -19,9 +19,8 @@ namespace HK.AutoAnt.GameControllers
         
         public void Do(InputControllers.Events.DragData data)
         {
-            // FIXME: ドラッグ移動量をオプションか何かで編集出来るように
-            var delta = data.DeltaPosition * 0.025f;
-            this.gameCameraController.Move(delta.y, delta.x);
+            var d = data.DeltaPosition;
+            this.gameCameraController.Move(new Vector2(d.x, d.y));
         }
     }
 }


### PR DESCRIPTION
## 変更点概要
- つまり指に追従してカメラが移動するように
    - 参考
         - https://spphire9.wordpress.com/2013/11/22/unity%E3%81%AE%E6%AD%A3%E5%B0%84%E5%BD%B1%E3%81%AE%E3%82%AB%E3%83%A1%E3%83%A9%E3%81%A7%E7%A7%BB%E5%8B%95%E9%87%8F%E3%82%92%E5%A4%89%E6%8F%9B%E3%81%99%E3%82%8B/

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 🍐 
## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
