### PR TITLE
CellEventCategoryを追加

### DIFF
--- a/Assets/HK/AutoAnt/DataSources/CellEvents/Facility/101000.asset
+++ b/Assets/HK/AutoAnt/DataSources/CellEvents/Facility/101000.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: de720865f3a87453b819dddba9f5f72d, type: 3}
   m_Name: 101000
   m_EditorClassIdentifier: 
+  category: 1
   condition: {fileID: 11400000, guid: 4c0900e2970f54676923b8814d79aff7, type: 2}
   size: 1
   constructionSE: {fileID: 8300000, guid: 0468cadb0012c46d2a975df3af8b8038, type: 3}

--- a/Assets/HK/AutoAnt/DataSources/CellEvents/Housing/100000.asset
+++ b/Assets/HK/AutoAnt/DataSources/CellEvents/Housing/100000.asset
@@ -12,6 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f516f9fbb86244f0fa699dfa4100160a, type: 3}
   m_Name: 100000
   m_EditorClassIdentifier: 
+  category: 0
   condition: {fileID: 11400000, guid: 4c0900e2970f54676923b8814d79aff7, type: 2}
   size: 1
   constructionSE: {fileID: 8300000, guid: 0468cadb0012c46d2a975df3af8b8038, type: 3}
@@ -22,5 +23,4 @@ MonoBehaviour:
     type: 3}
   gimmickPrefab: {fileID: 1696405967700200454, guid: 81339a340327d4660946cc3c5dee835b,
     type: 3}
-  BasePopulationAmount: 10
   CurrentPopulation: 0

--- a/Assets/HK/AutoAnt/Editor/QuickSheetSettings/CellEvent.asset
+++ b/Assets/HK/AutoAnt/Editor/QuickSheetSettings/CellEvent.asset
@@ -24,7 +24,11 @@ MonoBehaviour:
     isEnable: 0
     isArray: 0
   - type: 1
-    name: CellEventType
+    name: ClassName
+    isEnable: 0
+    isArray: 0
+  - type: 1
+    name: Category
     isEnable: 0
     isArray: 0
   - type: 1

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -168,6 +168,7 @@ namespace HK.AutoAnt.CellControllers.Events
             }
 
             result.ApplyProperty(data);
+            EditorUtility.SetDirty(result);
 
             return result;
         } 

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -23,7 +23,7 @@ namespace HK.AutoAnt.CellControllers.Events
         [SerializeField]
         protected Constants.CellEventCategory category;
         public Constants.CellEventCategory Category => this.category;
-        
+
         [SerializeField]
         protected CellEventGenerateCondition condition = null;
 
@@ -143,14 +143,14 @@ namespace HK.AutoAnt.CellControllers.Events
 #if UNITY_EDITOR
         public static CellEvent GetOrCreateAsset(Database.SpreadSheetData.CellEventData data)
         {
-            switch(data.Celleventtype)
+            switch(data.Classname)
             {
                 case "Housing":
                     return CellEvent.InternalGetOrCreateAsset<Housing>(data);
                 case "Facility":
                     return CellEvent.InternalGetOrCreateAsset<Facility>(data);
                 default:
-                    Debug.LogError($"CellEventType = {data.Celleventtype}は未対応の値です");
+                    Debug.LogError($"CellEventType = {data.Classname}は未対応の値です");
                     return null;
             }
         }
@@ -158,7 +158,7 @@ namespace HK.AutoAnt.CellControllers.Events
         protected static T InternalGetOrCreateAsset<T>(Database.SpreadSheetData.CellEventData data)
             where T : CellEvent
         {
-            var path = $"Assets/HK/AutoAnt/DataSources/CellEvents/{data.Celleventtype}/{data.Id}.asset";
+            var path = $"Assets/HK/AutoAnt/DataSources/CellEvents/{data.Classname}/{data.Id}.asset";
             var result = AssetDatabase.LoadAssetAtPath<T>(path);
             if (result == null)
             {
@@ -174,6 +174,7 @@ namespace HK.AutoAnt.CellControllers.Events
 
         protected virtual void ApplyProperty(Database.SpreadSheetData.CellEventData data)
         {
+            this.category = (Constants.CellEventCategory)Enum.Parse(typeof(Constants.CellEventCategory), data.Category);
             this.condition = AssetDatabase.LoadAssetAtPath<CellEventGenerateCondition>($"Assets/HK/AutoAnt/DataSources/CellEvents/Conditions/{data.Condition}.asset");
             this.size = data.Size;
             this.constructionSE = AssetDatabase.LoadAssetAtPath<AudioClip>($"Assets/HK/AutoAnt/DataSources/SE/{data.Constructionse}.mp3");

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -21,6 +21,10 @@ namespace HK.AutoAnt.CellControllers.Events
     public abstract class CellEvent : ScriptableObject, ICellEvent
     {
         [SerializeField]
+        protected Constants.CellEventCategory category;
+        public Constants.CellEventCategory Category => this.category;
+        
+        [SerializeField]
         protected CellEventGenerateCondition condition = null;
 
         [SerializeField]

--- a/Assets/HK/AutoAnt/Scripts/Database/Runtime/CellEventData.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/Runtime/CellEventData.cs
@@ -16,8 +16,12 @@ int id;
 public int Id { get {return id; } set { id = value;} }
 
 [SerializeField]
-string celleventtype;
-public string Celleventtype { get {return celleventtype; } set { celleventtype = value;} }
+string classname;
+public string Classname { get {return classname; } set { classname = value;} }
+
+[SerializeField]
+string category;
+public string Category { get {return category; } set { category = value;} }
 
 [SerializeField]
 string condition;

--- a/Assets/HK/AutoAnt/Scripts/Systems/Constants.cs
+++ b/Assets/HK/AutoAnt/Scripts/Systems/Constants.cs
@@ -41,4 +41,22 @@ namespace HK.AutoAnt.Constants
         /// </summary>
         ExploringMode,
     }
+
+    public enum CellEventCategory
+    {
+        /// <summary>
+        /// 住宅
+        /// </summary>
+        Housing,
+
+        /// <summary>
+        /// 農場
+        /// </summary>
+        Farm,
+
+        /// <summary>
+        /// 工場
+        /// </summary>
+        Factory,
+    }
 }


### PR DESCRIPTION
## 変更点概要
- 住宅、農業、工業の区別をつけられるようになりました
- `CellEventType.Category`で取得可能です

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- かるーく見ていただければ

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
