### PR TITLE
セルを追加したりイベント追加するデバッグを追加

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -40,11 +40,6 @@ namespace HK.AutoAnt.CellControllers
             Assert.IsNotNull(cellEventRecord);
             Assert.IsNotNull(cellEventRecord.EventData);
 
-            var levelUpCostRecord = this.gameSystem.MasterData.LevelUpCost.Records.Get(cellEventRecordId, 0);
-            Assert.IsNotNull(levelUpCostRecord);
-
-            levelUpCostRecord.Cost.Consume(this.gameSystem.User, this.gameSystem.MasterData.Item);
-
             var cellEventInstance = UnityEngine.Object.Instantiate(cellEventRecord.EventData);
 
             // (Clone)という文字列が要らないのでnameを代入する必要がある

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
@@ -13,6 +13,7 @@ using UniRx;
 /// </summary>
 public partial class SROptions
 {
+    [Sort(1000)]
     [Category("Game")]
     [DisplayName("生成する建設物のID")]
     public int ChangeCellEventGenerator
@@ -27,6 +28,7 @@ public partial class SROptions
         }
     }
 
+    [Sort(1000)]
     [Category("Game")]
     [DisplayName("ポップアップテスト")]
     public void SimplePopupText()
@@ -37,6 +39,34 @@ public partial class SROptions
 
         popup.Broker.Receive<PopupEvents.Response>()
             .Subscribe(x => Debug.Log(x.Result));
+    }
+
+    private int addCellRange = 5;
+    [Sort(1000)]
+    [Category("Game/Cell")]
+    [DisplayName("追加するセル範囲")]
+    public int AddCellRange { get { return this.addCellRange; } set { this.addCellRange = value; } }
+
+    [Sort(1001)]
+    [Category("Game/Cell")]
+    [DisplayName("セル追加")]
+    public void InvokeAddCellRange()
+    {
+        const int grasslandId = 100100;
+        var cellManager = GameSystem.Instance.CellManager;
+        cellManager.Mapper.GetRange(Vector2Int.zero, this.addCellRange, (id) =>
+        {
+            if(cellManager.Mapper.Cell.Map.ContainsKey(id))
+            {
+                cellManager.CellGenerator.Replace(grasslandId, id);
+            }
+            else
+            {
+                cellManager.CellGenerator.Generate(grasslandId, id);
+            }
+
+            return true;
+        });
     }
 }
 // #endif

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
@@ -90,6 +90,27 @@ public partial class SROptions
         });
     }
 
+    [Sort(1003)]
+    [Category("Game/Cell")]
+    [DisplayName("商業追加")]
+    public void InvokeAddCellEventFacility()
+    {
+        const int facilityId = 101000;
+        var cellManager = GameSystem.Instance.CellManager;
+        cellManager.Mapper.GetRange(Vector2Int.zero, this.addCellRange, (id) =>
+        {
+            var cell = cellManager.Mapper.Cell.Map[id];
+            if (cellManager.Mapper.CellEvent.Map.ContainsKey(id))
+            {
+                cellManager.EventGenerator.Erase(cell);
+            }
+
+            cellManager.EventGenerator.Generate(cell, facilityId, false);
+
+            return true;
+        });
+    }
+
 
 }
 // #endif

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
@@ -56,7 +56,7 @@ public partial class SROptions
         var cellManager = GameSystem.Instance.CellManager;
         cellManager.Mapper.GetRange(Vector2Int.zero, this.addCellRange, (id) =>
         {
-            if(cellManager.Mapper.Cell.Map.ContainsKey(id))
+            if (cellManager.Mapper.Cell.Map.ContainsKey(id))
             {
                 cellManager.CellGenerator.Replace(grasslandId, id);
             }
@@ -68,5 +68,28 @@ public partial class SROptions
             return true;
         });
     }
+
+    [Sort(1002)]
+    [Category("Game/Cell")]
+    [DisplayName("住宅追加")]
+    public void InvokeAddCellEventHousing()
+    {
+        const int housingId = 100000;
+        var cellManager = GameSystem.Instance.CellManager;
+        cellManager.Mapper.GetRange(Vector2Int.zero, this.addCellRange, (id) =>
+        {
+            var cell = cellManager.Mapper.Cell.Map[id];
+            if (cellManager.Mapper.CellEvent.Map.ContainsKey(id))
+            {
+                cellManager.EventGenerator.Erase(cell);
+            }
+
+            cellManager.EventGenerator.Generate(cell, housingId, false);
+
+            return true;
+        });
+    }
+
+
 }
 // #endif

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
@@ -1,5 +1,6 @@
 ﻿using HK.AutoAnt.CameraControllers;
 using HK.AutoAnt.CellControllers;
+using HK.AutoAnt.Extensions;
 using HK.AutoAnt.InputControllers;
 using HK.AutoAnt.Systems;
 using UnityEngine;
@@ -21,7 +22,8 @@ namespace HK.AutoAnt.GameControllers
 
         public void Do(InputControllers.Events.ClickData data)
         {
-            var cell = CellManager.GetCell(GameSystem.Instance.Cameraman.Camera.ScreenPointToRay(data.Position));
+            var gameSystem = GameSystem.Instance;
+            var cell = CellManager.GetCell(gameSystem.Cameraman.Camera.ScreenPointToRay(data.Position));
             if(cell == null)
             {
                 return;
@@ -29,6 +31,11 @@ namespace HK.AutoAnt.GameControllers
 
             if(this.eventGenerator.CanGenerate(cell, this.eventGenerator.RecordId))
             {
+                var levelUpCostRecord = gameSystem.MasterData.LevelUpCost.Records.Get(this.eventGenerator.RecordId, 0);
+                Assert.IsNotNull(levelUpCostRecord);
+
+                levelUpCostRecord.Cost.Consume(gameSystem.User, gameSystem.MasterData.Item);
+
                 this.eventGenerator.Generate(cell, this.eventGenerator.RecordId, false);
             }
         }


### PR DESCRIPTION
## 変更点概要
- SROptionに以下のデバッグを追加しました
    - `追加するセル範囲`
        - 次のデバッグで実行できる範囲を指定します
    - `セル追加`
        - `追加するセル範囲`からセルを追加します
    - `住宅追加`
        - `追加するセル範囲`から住宅を追加します
    - `商業追加`
        - `追加するセル範囲`から商業を追加します
<img width="278" alt="スクリーンショット 2019-06-28 1 22 59" src="https://user-images.githubusercontent.com/5396546/60283207-9bf69d80-9943-11e9-8dbf-fdc322f6dd09.png">

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 🍐 

## 特に見なくていい箇所
- 🍐 

## その他
- これによって色々見えてきた
    - 住宅めっちゃ処理食う
        - まあ毎フレ人口追加してるからしょうがない
        - 問題なのは住宅ごとにUIを更新している
            - そうではなく毎フレーム、UIの更新が必要な場合のみ更新する処理にすれば劇的に変わるはず
    - 商業は問題ない
        - 強いて言えばWhere句
            - やはり愚直にif文使ったほうがコスパは良い・・・
    - 大きな人口が一気に減るとアサート出る問題
        - 計算誤差で人口がマイナスになっているかも
            - 些細な値のハズだから丸め込みしちゃってもいいかも