### PR TITLE
ヘッダーUIの最適化

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/UI/HeaderMoneyController.cs
+++ b/Assets/HK/AutoAnt/Scripts/UI/HeaderMoneyController.cs
@@ -3,6 +3,7 @@ using HK.AutoAnt.Systems;
 using HK.Framework.Text;
 using TMPro;
 using UniRx;
+using UniRx.Triggers;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -19,11 +20,20 @@ namespace HK.AutoAnt.UI
         [SerializeField]
         private StringAsset.Finder format = null;
 
-        void Start()
+        private double cachedMoney;
+
+        void Awake()
         {
-            GameSystem.Instance.User.Wallet.MoneyAsObservable
-                .SubscribeWithState(this, (money, _this) =>
+            GameSystem.Instance.UpdateAsObservable()
+                .SubscribeWithState(this, (_, _this) =>
                 {
+                    var money = GameSystem.Instance.User.Wallet.Money;
+                    if(_this.cachedMoney == money)
+                    {
+                        return;
+                    }
+
+                    this.cachedMoney = money;
                     _this.value.text = _this.format.Format(money.ToReadableString("###.00"));
                 })
                 .AddTo(this);

--- a/Assets/HK/AutoAnt/Scripts/UI/HeaderMoneyController.cs
+++ b/Assets/HK/AutoAnt/Scripts/UI/HeaderMoneyController.cs
@@ -33,7 +33,7 @@ namespace HK.AutoAnt.UI
                         return;
                     }
 
-                    this.cachedMoney = money;
+                    _this.cachedMoney = money;
                     _this.value.text = _this.format.Format(money.ToReadableString("###.00"));
                 })
                 .AddTo(this);

--- a/Assets/HK/AutoAnt/Scripts/UI/HeaderPopularityController.cs
+++ b/Assets/HK/AutoAnt/Scripts/UI/HeaderPopularityController.cs
@@ -3,6 +3,7 @@ using HK.AutoAnt.Systems;
 using HK.Framework.Text;
 using TMPro;
 using UniRx;
+using UniRx.Triggers;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -19,12 +20,21 @@ namespace HK.AutoAnt.UI
         [SerializeField]
         private StringAsset.Finder format = null;
 
+        private double cachedPopularity;
+
         void Start()
         {
-            GameSystem.Instance.User.Town.Popularity
-                .SubscribeWithState(this, (x, _this) =>
+            GameSystem.Instance.UpdateAsObservable()
+                .SubscribeWithState(this, (_, _this) =>
                 {
-                    _this.value.text = _this.format.Format(x.ToReadableString("###.00"));
+                    var popularity = GameSystem.Instance.User.Town.Popularity.Value;
+                    if(_this.cachedPopularity == popularity)
+                    {
+                        return;
+                    }
+
+                    _this.cachedPopularity = popularity;
+                    _this.value.text = _this.format.Format(popularity.ToReadableString("###.00"));
                 })
                 .AddTo(this);
         }

--- a/Assets/HK/AutoAnt/Scripts/UI/HeaderPopulationController.cs
+++ b/Assets/HK/AutoAnt/Scripts/UI/HeaderPopulationController.cs
@@ -3,6 +3,7 @@ using HK.AutoAnt.Systems;
 using HK.Framework.Text;
 using TMPro;
 using UniRx;
+using UniRx.Triggers;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -19,12 +20,21 @@ namespace HK.AutoAnt.UI
         [SerializeField]
         private StringAsset.Finder format = null;
 
+        private double cachedPopulation;
+
         void Start()
         {
-            GameSystem.Instance.User.Town.Population
-                .SubscribeWithState(this, (x, _this) =>
+            GameSystem.Instance.UpdateAsObservable()
+                .SubscribeWithState(this, (_, _this) =>
                 {
-                    _this.value.text = _this.format.Format(x.ToReadableString("###.00"));
+                    var population = GameSystem.Instance.User.Town.Population.Value;
+                    if(_this.cachedPopulation == population)
+                    {
+                        return;
+                    }
+
+                    _this.cachedPopulation = population;
+                    _this.value.text = _this.format.Format(population.ToReadableString("###.00"));
                 })
                 .AddTo(this);
         }


### PR DESCRIPTION
## 変更点概要
- 現状、住宅を10*10配置したら30FPSすら保てない状況
- これは住宅一個一個が人口UIを更新していたため
- そうではなく、毎フレーム一回だけ更新するように修正しました
- さらに値に変化が無い場合は更新しないようにしたためある程度コスト削減になっているはず（お金や人口はほぼ毎フレーム加算されるので意味があんまりない・・・）

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 軽くなった？

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
