### PR TITLE
詳細ポップアップ表示時のカメラのフォーカス処理にミスがあった

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/CameraControllers/GameCameraController.cs
+++ b/Assets/HK/AutoAnt/Scripts/CameraControllers/GameCameraController.cs
@@ -23,13 +23,13 @@ namespace HK.AutoAnt.CameraControllers
                 .Where(x => x != null)
                 .SubscribeWithState(this, (x, _this) =>
                 {
-                    var position = x.SelectCellEvent.Origin;
+                    var position = x.SelectCellEvent.Gimmick.transform.position;
                     var cameraman = GameSystem.Instance.Cameraman;
                     var camera = cameraman.Camera;
                     var forward = Vector3.Scale(camera.transform.forward, new Vector3(1.0f, 0.0f, 1.0f)).normalized;
                     var offset = forward * _this.offsetCellEventDetailsPopupFocus;
 
-                    cameraman.Position = new Vector3(position.x, 0.0f, position.y) + offset;
+                    cameraman.Position = new Vector3(position.x, 0.0f, position.z) + offset;
                 })
                 .AddTo(this);
         }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -65,7 +65,7 @@ namespace HK.AutoAnt.CellControllers.Events
         /// </summary>
         protected readonly CompositeDisposable instanceEvents = new CompositeDisposable();
 
-        protected GameObject gimmick;
+        public GameObject Gimmick { get; protected set; }
 
         private MasterDataCellEvent.Record cachedRecord;
 
@@ -101,9 +101,9 @@ namespace HK.AutoAnt.CellControllers.Events
             // 自分自身のマスターデータを取得してデータを参照している
             // セーブデータから読み込む時にアセットの参照はセーブしていないのでちょっとややこしい作りになっている
             this.cachedRecord = gameSystem.MasterData.CellEvent.Records.Get(this.Id);
-            this.gimmick = this.cachedRecord.EventData.CreateGimmickController(this.Origin);
+            this.Gimmick = this.cachedRecord.EventData.CreateGimmickController(this.Origin);
 
-            foreach(var g in this.gimmick.GetComponentsInChildren<ICellEventGimmick>())
+            foreach(var g in this.Gimmick.GetComponentsInChildren<ICellEventGimmick>())
             {
                 g.Attach(this);
             }
@@ -115,7 +115,7 @@ namespace HK.AutoAnt.CellControllers.Events
 
                 Assert.IsNotNull(this.cachedRecord.EventData.constructionEffect, $"Id = {this.Id}の建設時のエフェクト生成に失敗しました");
                 var effect = this.cachedRecord.EventData.constructionEffect.Rent();
-                effect.transform.position = this.gimmick.transform.position;
+                effect.transform.position = this.Gimmick.transform.position;
                 effect.transform.localScale = Vector3.one * this.cachedRecord.EventData.size;
             }
         }
@@ -128,7 +128,7 @@ namespace HK.AutoAnt.CellControllers.Events
             // セーブデータから読み込む時にアセットの参照はセーブしていないのでちょっとややこしい作りになっている
             var record = gameSystem.MasterData.CellEvent.Records.Get(this.Id);
 
-            foreach (var g in this.gimmick.GetComponentsInChildren<ICellEventGimmick>())
+            foreach (var g in this.Gimmick.GetComponentsInChildren<ICellEventGimmick>())
             {
                 g.Detach(this);
             }
@@ -138,10 +138,10 @@ namespace HK.AutoAnt.CellControllers.Events
 
             Assert.IsNotNull(record.EventData.destructionEffect, $"Id = {this.Id}の破壊時のエフェクト生成に失敗しました");
             var effect = record.EventData.destructionEffect.Rent();
-            effect.transform.position = this.gimmick.transform.position;
+            effect.transform.position = this.Gimmick.transform.position;
             effect.transform.localScale = Vector3.one * record.EventData.size;
 
-            Destroy(this.gimmick.gameObject);
+            Destroy(this.Gimmick.gameObject);
         }
 
         public bool CanGenerate(Cell origin, int cellEventRecordId, GameSystem gameSystem, CellMapper cellMapper)


### PR DESCRIPTION
## 変更点概要
- セルイベントの座標取得がおかしかったので、遠いセルイベントをクリックするとカメラの座標がおかしくなってた

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- カメラおかしくない？

## 特に見なくていい箇所
- 🍐 
## その他
- 🍐 