### PR TITLE
なぜ建てられなかったか通知UIで表示されるように

### DIFF
--- a/Assets/HK/AutoAnt/DataSources/StringAsset/UI.asset
+++ b/Assets/HK/AutoAnt/DataSources/StringAsset/UI.asset
@@ -69,3 +69,19 @@ MonoBehaviour:
       ja: OK
       en: 
     guid: 1beb83dc-5df1-49bc-9ae8-8270ab59a33b
+  - value:
+      ja: "\u571F\u5730\u304C\u3042\u308A\u307E\u305B\u3093\uFF01"
+      en: 
+    guid: 9e8a0fcc-a657-40b7-b662-6065b22009c1
+  - value:
+      ja: "\u4ED6\u306E\u5EFA\u7269\u304C\u3042\u308A\u307E\u3059\uFF01"
+      en: 
+    guid: d120e9e2-72fa-4642-b776-27c4ff67ec08
+  - value:
+      ja: "\u7D20\u6750\u304C\u8DB3\u308A\u307E\u305B\u3093\uFF01"
+      en: 
+    guid: 519b9495-4085-4dc2-891b-57a23e8c07e2
+  - value:
+      ja: "\u3053\u3053\u306B\u5EFA\u7269\u3092\u5EFA\u3066\u3089\u308C\u307E\u305B\u3093\uFF01"
+      en: 
+    guid: c596e9ae-402c-4e86-a4f7-0a65f2b30fdd

--- a/Assets/HK/AutoAnt/Prefabs/UI/Notification.prefab
+++ b/Assets/HK/AutoAnt/Prefabs/UI/Notification.prefab
@@ -69,7 +69,7 @@ MonoBehaviour:
     target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
     value: "\u571F\u5730\u304C\u3042\u308A\u307E\u305B\u3093\uFF01"
     guid: 9e8a0fcc-a657-40b7-b662-6065b22009c1
-  alreadyExistCellEventFormat:
+  alreadyExistsCellEventFormat:
     target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
     value: "\u4ED6\u306E\u5EFA\u7269\u304C\u3042\u308A\u307E\u3059\uFF01"
     guid: d120e9e2-72fa-4642-b776-27c4ff67ec08

--- a/Assets/HK/AutoAnt/Prefabs/UI/Notification.prefab
+++ b/Assets/HK/AutoAnt/Prefabs/UI/Notification.prefab
@@ -65,6 +65,22 @@ MonoBehaviour:
     target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
     value: '{0} +{1} ({2})'
     guid: 65d51f7d-b2d2-4668-848e-3b79864930c3
+  notCell:
+    target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
+    value: "\u571F\u5730\u304C\u3042\u308A\u307E\u305B\u3093\uFF01"
+    guid: 9e8a0fcc-a657-40b7-b662-6065b22009c1
+  alreadyExistCellEventFormat:
+    target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
+    value: "\u4ED6\u306E\u5EFA\u7269\u304C\u3042\u308A\u307E\u3059\uFF01"
+    guid: d120e9e2-72fa-4642-b776-27c4ff67ec08
+  notEnoughCost:
+    target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
+    value: "\u7D20\u6750\u304C\u8DB3\u308A\u307E\u305B\u3093\uFF01"
+    guid: 519b9495-4085-4dc2-891b-57a23e8c07e2
+  notEnoughCondition:
+    target: {fileID: 11400000, guid: f40968edcf2934099bc01ae4e04e0b31, type: 2}
+    value: "\u3053\u3053\u306B\u5EFA\u7269\u3092\u5EFA\u3066\u3089\u308C\u307E\u305B\u3093\uFF01"
+    guid: c596e9ae-402c-4e86-a4f7-0a65f2b30fdd
 --- !u!114 &7793537076881952495
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/CellEventGenerator.cs
@@ -87,7 +87,7 @@ namespace HK.AutoAnt.CellControllers
         /// <summary>
         /// イベントが作成可能か返す
         /// </summary>
-        public bool CanGenerate(Cell cell, int cellEventRecordId)
+        public Constants.CellEventGenerateEvalute CanGenerate(Cell cell, int cellEventRecordId)
         {
             return this.GeneratableCellEvent.CanGenerate(cell, cellEventRecordId, this.gameSystem, this.cellMapper);
         }

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -152,7 +152,7 @@ namespace HK.AutoAnt.CellControllers.Events
             Destroy(this.Gimmick.gameObject);
         }
 
-        public bool CanGenerate(Cell origin, int cellEventRecordId, GameSystem gameSystem, CellMapper cellMapper)
+        public Constants.CellEventGenerateEvalute CanGenerate(Cell origin, int cellEventRecordId, GameSystem gameSystem, CellMapper cellMapper)
         {
             Assert.IsNotNull(this.condition);
 
@@ -161,14 +161,14 @@ namespace HK.AutoAnt.CellControllers.Events
             // 配置したいところにセルがない場合は生成できない
             if(cellPositions.Count != this.size * this.size)
             {
-                return false;
+                return Constants.CellEventGenerateEvalute.NotCell;
             }
 
             // 配置したいセルにイベントがあった場合は生成できない
             var cells = cellMapper.GetCells(cellPositions);
             if(Array.FindIndex(cells, c => cellMapper.HasEvent(c)) != -1)
             {
-                return false;
+                return Constants.CellEventGenerateEvalute.AlreadyCellEvent;
             }
 
             // コストが満たしていない場合は生成できない
@@ -176,10 +176,16 @@ namespace HK.AutoAnt.CellControllers.Events
             Assert.IsNotNull(masterData, $"CellEventRecordId = {cellEventRecordId}の{typeof(MasterDataLevelUpCost.Record)}がありませんでした");
             if(!masterData.Cost.IsEnough(gameSystem.User, gameSystem.MasterData.Item))
             {
-                return false;
+                return Constants.CellEventGenerateEvalute.NotEnoughCost;
             }
 
-            return this.condition.Evalute(cells);
+            // セルイベントごとの条件を満たしていない場合は生成できない
+            if(!this.condition.Evalute(cells))
+            {
+                return Constants.CellEventGenerateEvalute.NotEnoughCondition;
+            }
+
+            return Constants.CellEventGenerateEvalute.Possible;
         }
 
         public virtual void OnClick(Cell owner)

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/CellEvent.cs
@@ -168,7 +168,7 @@ namespace HK.AutoAnt.CellControllers.Events
             var cells = cellMapper.GetCells(cellPositions);
             if(Array.FindIndex(cells, c => cellMapper.HasEvent(c)) != -1)
             {
-                return Constants.CellEventGenerateEvalute.AlreadyCellEvent;
+                return Constants.CellEventGenerateEvalute.AlreadyExistsCellEvent;
             }
 
             // コストが満たしていない場合は生成できない

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/ICellEvent.cs
@@ -68,7 +68,7 @@ namespace HK.AutoAnt.CellControllers.Events
         /// <summary>
         /// 作成可能か返す
         /// </summary>
-        bool CanGenerate(Cell owner, int cellEventRecordId, GameSystem gameSystem, CellMapper cellMapper);
+        Constants.CellEventGenerateEvalute CanGenerate(Cell owner, int cellEventRecordId, GameSystem gameSystem, CellMapper cellMapper);
 
         /// <summary>
         /// セルがクリックされた時の処理

--- a/Assets/HK/AutoAnt/Scripts/Events/ProcessedGenerateCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/Events/ProcessedGenerateCellEvent.cs
@@ -1,0 +1,17 @@
+﻿using HK.Framework.EventSystems;
+using UnityEngine;
+using UnityEngine.Assertions;
+
+namespace HK.AutoAnt.Events
+{
+    /// <summary>
+    /// セルイベントの生成処理を行った際のイベント
+    /// </summary>
+    public sealed class ProcessedGenerateCellEvent : Message<ProcessedGenerateCellEvent, Constants.CellEventGenerateEvalute>
+    {
+        /// <summary>
+        /// 建設評価
+        /// </summary>
+        public Constants.CellEventGenerateEvalute Evalute => this.param1;
+    }
+}

--- a/Assets/HK/AutoAnt/Scripts/Events/ProcessedGenerateCellEvent.cs.meta
+++ b/Assets/HK/AutoAnt/Scripts/Events/ProcessedGenerateCellEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7b849d5bbcc443e192a56a47f4e5602
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
@@ -29,7 +29,8 @@ namespace HK.AutoAnt.GameControllers
                 return;
             }
 
-            if(this.eventGenerator.CanGenerate(cell, this.eventGenerator.RecordId))
+            var evalute = this.eventGenerator.CanGenerate(cell, this.eventGenerator.RecordId);
+            if(evalute == Constants.CellEventGenerateEvalute.Possible)
             {
                 var levelUpCostRecord = gameSystem.MasterData.LevelUpCost.Records.Get(this.eventGenerator.RecordId, 0);
                 Assert.IsNotNull(levelUpCostRecord);

--- a/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/GameControllers/InputActions/Elements/ClickToGenerateCellEvent.cs
@@ -1,8 +1,10 @@
 ﻿using HK.AutoAnt.CameraControllers;
 using HK.AutoAnt.CellControllers;
+using HK.AutoAnt.Events;
 using HK.AutoAnt.Extensions;
 using HK.AutoAnt.InputControllers;
 using HK.AutoAnt.Systems;
+using HK.Framework.EventSystems;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -39,6 +41,8 @@ namespace HK.AutoAnt.GameControllers
 
                 this.eventGenerator.Generate(cell, this.eventGenerator.RecordId, false);
             }
+
+            Broker.Global.Publish(ProcessedGenerateCellEvent.Get(evalute));
         }
     }
 }

--- a/Assets/HK/AutoAnt/Scripts/Systems/Constants.cs
+++ b/Assets/HK/AutoAnt/Scripts/Systems/Constants.cs
@@ -41,4 +41,35 @@ namespace HK.AutoAnt.Constants
         /// </summary>
         Road,
     }
+
+    /// <summary>
+    /// セルイベントを生成可能かの評価タイプ
+    /// </summary>
+    public enum CellEventGenerateEvalute
+    {
+        /// <summary>
+        /// 建設可能
+        /// </summary>
+        Possible,
+
+        /// <summary>
+        /// セルが無い
+        /// </summary>
+        NotCell,
+
+        /// <summary>
+        /// 既に別のセルイベントがある
+        /// </summary>
+        AlreadyCellEvent,
+
+        /// <summary>
+        /// コストが足りない
+        /// </summary>
+        NotEnoughCost,
+
+        /// <summary>
+        /// セルイベントごとの条件を満たしていない
+        /// </summary>
+        NotEnoughCondition,
+    }
 }

--- a/Assets/HK/AutoAnt/Scripts/Systems/Constants.cs
+++ b/Assets/HK/AutoAnt/Scripts/Systems/Constants.cs
@@ -60,7 +60,7 @@ namespace HK.AutoAnt.Constants
         /// <summary>
         /// 既に別のセルイベントがある
         /// </summary>
-        AlreadyCellEvent,
+        AlreadyExistsCellEvent,
 
         /// <summary>
         /// コストが足りない

--- a/Assets/HK/AutoAnt/Scripts/UI/NotificationUIController.cs
+++ b/Assets/HK/AutoAnt/Scripts/UI/NotificationUIController.cs
@@ -36,7 +36,7 @@ namespace HK.AutoAnt.UI
         /// 既にセルイベントが存在するのにセルイベントを生成しようとした時のメッセージフォーマット
         /// </summary>
         [SerializeField]
-        private StringAsset.Finder alreadyExistCellEventFormat = null;
+        private StringAsset.Finder alreadyExistsCellEventFormat = null;
 
         /// <summary>
         /// コストが足りないのにセルイベントを生成しようとした時のメッセージフォーマット
@@ -88,8 +88,8 @@ namespace HK.AutoAnt.UI
             {
                 case Constants.CellEventGenerateEvalute.NotCell:
                     return this.notCell.Get;
-                case Constants.CellEventGenerateEvalute.AlreadyCellEvent:
-                    return this.alreadyExistCellEventFormat.Get;
+                case Constants.CellEventGenerateEvalute.AlreadyExistsCellEvent:
+                    return this.alreadyExistsCellEventFormat.Get;
                 case Constants.CellEventGenerateEvalute.NotEnoughCost:
                     return this.notEnoughCost.Get;
                 case Constants.CellEventGenerateEvalute.NotEnoughCondition:

--- a/Assets/HK/AutoAnt/Scripts/UI/NotificationUIController.cs
+++ b/Assets/HK/AutoAnt/Scripts/UI/NotificationUIController.cs
@@ -20,8 +20,35 @@ namespace HK.AutoAnt.UI
         [SerializeField]
         private float delayElementDestroy = 0.0f;
 
+        /// <summary>
+        /// アイテムを取得した時のメッセージフォーマット
+        /// </summary>
         [SerializeField]
         private StringAsset.Finder acquireItemFormat = null;
+
+        /// <summary>
+        /// セルが無い時にセルイベントを生成しようとした時のメッセージフォーマット
+        /// </summary>
+        [SerializeField]
+        private StringAsset.Finder notCell = null;
+
+        /// <summary>
+        /// 既にセルイベントが存在するのにセルイベントを生成しようとした時のメッセージフォーマット
+        /// </summary>
+        [SerializeField]
+        private StringAsset.Finder alreadyExistCellEventFormat = null;
+
+        /// <summary>
+        /// コストが足りないのにセルイベントを生成しようとした時のメッセージフォーマット
+        /// </summary>
+        [SerializeField]
+        private StringAsset.Finder notEnoughCost = null;
+
+        /// <summary>
+        /// セルイベントごとの条件を満たしていないのにセルイベントを生成しようとした時のメッセージフォーマット
+        /// </summary>
+        [SerializeField]
+        private StringAsset.Finder notEnoughCondition = null;
 
         void Awake()
         {
@@ -40,11 +67,37 @@ namespace HK.AutoAnt.UI
                     _this.CreateElement(x.Message, x.MessageType);
                 })
                 .AddTo(this);
+
+            Broker.Global.Receive<ProcessedGenerateCellEvent>()
+                .Where(x => x.Evalute != Constants.CellEventGenerateEvalute.Possible)
+                .SubscribeWithState(this, (x, _this) =>
+                {
+                    _this.CreateElement(_this.GetProcessedCellEventMessage(x.Evalute), NotificationUIElement.MessageType.Error);
+                })
+                .AddTo(this);
         }
 
         private void CreateElement(string message, NotificationUIElement.MessageType messageType)
         {
             var element = this.elementPrefab.Rent(this.transform, message, messageType, this.delayElementDestroy);
+        }
+
+        private string GetProcessedCellEventMessage(Constants.CellEventGenerateEvalute evalute)
+        {
+            switch(evalute)
+            {
+                case Constants.CellEventGenerateEvalute.NotCell:
+                    return this.notCell.Get;
+                case Constants.CellEventGenerateEvalute.AlreadyCellEvent:
+                    return this.alreadyExistCellEventFormat.Get;
+                case Constants.CellEventGenerateEvalute.NotEnoughCost:
+                    return this.notEnoughCost.Get;
+                case Constants.CellEventGenerateEvalute.NotEnoughCondition:
+                    return this.notEnoughCondition.Get;
+                default:
+                    Assert.IsTrue(false, $"{evalute}は未対応です");
+                    return null;
+            }
         }
     }
 }


### PR DESCRIPTION
## 変更点概要
- #86 の対応
- 以下の状況で通知するようにしました
    - 土地が無い（2*2の建物を建てようとした時）
    - 既に建物がある
    - コストが足りない
    - セルイベントの条件を満たしていない（例えばBlankセルに配置不可能だったり）

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 伝わる？

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
