### PR TITLE
全てのセルイベントをアンロックするデバッグを追加

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Facility.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Facility.cs
@@ -60,7 +60,7 @@ namespace HK.AutoAnt.CellControllers.Events
         {
             base.Initialize(position, gameSystem, isInitializingGame);
             this.gameSystem = gameSystem;
-            this.LevelParameter = this.gameSystem.MasterData.FacilityLevelParameter.Records.Get(this.Id, this.Level);
+            this.UpdateLevelParameter();
             gameSystem.User.Town.AddPopularity(this.Popularity);
             this.gameSystem.UpdateAsObservable()
                 .Where(_ => this.CanProduce)
@@ -110,11 +110,18 @@ namespace HK.AutoAnt.CellControllers.Events
 
             this.LevelUp(this.gameSystem);
 
-            this.LevelParameter = this.gameSystem.MasterData.FacilityLevelParameter.Records.Get(this.Id, this.Level);
+            this.UpdateLevelParameter();
 
             // レベルアップ後の人気度を加算する
             var newPopularity = this.Popularity;
             this.gameSystem.User.Town.AddPopularity(newPopularity);
+        }
+
+        private void UpdateLevelParameter()
+        {
+            var levelParameter = this.gameSystem.MasterData.FacilityLevelParameter.Records.Get(this.Id, this.Level);
+            Assert.IsNotNull(levelParameter, $"Id = {this.Id}, Level = {this.Level} の {typeof(MasterDataFacilityLevelParameter)}がありませんでした");
+            this.LevelParameter = levelParameter;
         }
 
         /// <summary>

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.User.cs
@@ -32,10 +32,29 @@ public partial class SROptions
     public void AcquireItemAll()
     {
         var masterData = GameSystem.Instance.MasterData.Item;
-        foreach(var record in masterData.Records)
+        foreach (var record in masterData.Records)
         {
             GameSystem.Instance.User.Inventory.AddItem(record, 10);
         }
+    }
+
+    [Category(UserCategory)]
+    [DisplayName("全部アンロック")]
+    public void UnlockAll()
+    {
+        var unlockCellEvent = GameSystem.Instance.User.UnlockCellEvent;
+        var masterData = GameSystem.Instance.MasterData.CellEvent;
+        foreach(var record in masterData.Records)
+        {
+            if(unlockCellEvent.Elements.Contains(record.EventData.Id))
+            {
+                continue;
+            }
+
+            unlockCellEvent.Elements.Add(record.EventData.Id);
+        }
+
+        Debug.Log("全てのセルイベントをアンロックしました");
     }
 
     [Category(UserCategory)]

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -529,6 +529,7 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   scriptingDefineSymbols:
+    1: AA_DEBUG
     4: AA_DEBUG
     13: AA_DEBUG
   platformArchitecture: {}


### PR DESCRIPTION
## 変更点概要
- SRDebugの`Options/全部アンロック`を追加しました
- ついでに`FacilityLevelParameter`が無い場合はアサート出すようにしました

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 本当にアンロック出来る？

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
