### PR TITLE
LevelUpCostのアイテムはIDで指定するように

### DIFF
--- a/Assets/HK/AutoAnt/DataSources/Database/MasterData/LevelUpCost.asset
+++ b/Assets/HK/AutoAnt/DataSources/Database/MasterData/LevelUpCost.asset
@@ -23,40 +23,28 @@ MonoBehaviour:
     cost:
       money: 1500
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 2
   - id: 100000
     level: 2
     cost:
       money: 2000
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 4
   - id: 100000
     level: 3
     cost:
       money: 2500
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 8
   - id: 100000
     level: 4
     cost:
       money: 3000
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 12
   - id: 101000
     level: 0
@@ -143,38 +131,26 @@ MonoBehaviour:
     cost:
       money: 15000
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 4
   - id: 100001
     level: 2
     cost:
       money: 20000
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 8
   - id: 100001
     level: 3
     cost:
       money: 25000
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 16
   - id: 100001
     level: 4
     cost:
       money: 30000
       needItems:
-      - itemName:
-          target: {fileID: 11400000, guid: 1c726c3b488184fe7841f2d762b122d3, type: 2}
-          value: "\u85AA"
-          guid: 456e6773-1a7f-4c8c-92c0-08bd73b674ba
+      - itemId: 100000
         amount: 24

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/LevelUpCost.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/LevelUpCost.cs
@@ -48,7 +48,7 @@ namespace HK.AutoAnt.CellControllers
                 var json = JsonUtility.FromJson<NeedItem.RawData.Json>(data.Items);
                 this.needItems = json
                     .NeedItems
-                    .Select(x => new NeedItem(x.ItemName, x.Amount)).ToArray();
+                    .Select(x => new NeedItem(x.ItemId, x.Amount)).ToArray();
             }
         }
 #endif
@@ -90,8 +90,8 @@ namespace HK.AutoAnt.CellControllers
             /// アイテムの名前
             /// </summary>
             [SerializeField]
-            private StringAsset.Finder itemName = null;
-            public string ItemName => this.itemName.Get;
+            private int itemId = 0;
+            public int ItemId => this.itemId;
 
             /// <summary>
             /// 必要な量
@@ -101,10 +101,9 @@ namespace HK.AutoAnt.CellControllers
             public int Amount => this.amount;
 
 #if UNITY_EDITOR
-            public NeedItem(string itemName, int amount)
+            public NeedItem(int itemId, int amount)
             {
-                var stringAsset = AssetDatabase.LoadAssetAtPath<StringAsset>("Assets/HK/AutoAnt/DataSources/StringAsset/Item.asset");
-                this.itemName = stringAsset.CreateFinder(itemName);
+                this.itemId = itemId;
                 this.amount = amount;
             }
 #endif
@@ -114,7 +113,7 @@ namespace HK.AutoAnt.CellControllers
             /// </summary>
             public bool IsEnough(Inventory inventory, MasterDataItem masterData)
             {
-                var record = masterData.Records.Get(this.itemName.Get);
+                var record = masterData.Records.Get(this.itemId);
                 if(!inventory.Items.ContainsKey(record.Id))
                 {
                     return false;
@@ -129,7 +128,7 @@ namespace HK.AutoAnt.CellControllers
             public void Consume(Inventory inventory, MasterDataItem masterData)
             {
                 Assert.IsTrue(this.IsEnough(inventory, masterData));
-                var record = masterData.Records.Get(this.itemName.Get);
+                var record = masterData.Records.Get(this.itemId);
 
                 inventory.AddItem(record, -this.amount);
             }
@@ -137,7 +136,7 @@ namespace HK.AutoAnt.CellControllers
             [Serializable]
             public class RawData
             {
-                public string ItemName;
+                public int ItemId;
                 public int Amount;
 
                 public class Json

--- a/Assets/HK/AutoAnt/Scripts/Extensions/Extensions.CellControllers.Events.ILevelUpEvent.cs
+++ b/Assets/HK/AutoAnt/Scripts/Extensions/Extensions.CellControllers.Events.ILevelUpEvent.cs
@@ -85,11 +85,11 @@ namespace HK.AutoAnt.Extensions
                     popup.AddLevelUpCost(property =>
                     {
                         var inventoryItem = gameSystem.User.Inventory.Items;
-                        var itemRecord = gameSystem.MasterData.Item.Records.Get(n.ItemName);
+                        var itemRecord = gameSystem.MasterData.Item.Records.Get(n.ItemId);
                         var possessionItemAmount = inventoryItem.ContainsKey(itemRecord.Id) ? inventoryItem[itemRecord.Id] : 0;
                         var stringBuilder = new StringBuilder();
                         var color = (possessionItemAmount >= n.Amount) ? popup.EnoughLevelUpCostColor : popup.NotEnoughLevelUpCostColor;
-                        property.Prefix.text = n.ItemName;
+                        property.Prefix.text = itemRecord.Name;
                         property.Value.text = stringBuilder.AppendColorCode(color, popup.NeedItemValue.Format(possessionItemAmount, n.Amount)).ToString();
                     })
                 );
@@ -125,11 +125,11 @@ namespace HK.AutoAnt.Extensions
                     controller.AddProperty(property =>
                     {
                         var inventoryItem = gameSystem.User.Inventory.Items;
-                        var itemRecord = gameSystem.MasterData.Item.Records.Get(n.ItemName);
+                        var itemRecord = gameSystem.MasterData.Item.Records.Get(n.ItemId);
                         var possessionItemAmount = inventoryItem.ContainsKey(itemRecord.Id) ? inventoryItem[itemRecord.Id] : 0;
                         stringBuilder.Clear();
                         var color = controller.GetConditionColor(possessionItemAmount >= n.Amount);
-                        property.Prefix.text = n.ItemName;
+                        property.Prefix.text = itemRecord.Name;
                         property.Value.text = stringBuilder.AppendColorCode(color, controller.NeedItemFormat.Format(possessionItemAmount, n.Amount)).ToString();
                     })
                 );


### PR DESCRIPTION
## 変更点概要
- まだItemNameで指定していたので対応

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- [マスターデータ](https://docs.google.com/spreadsheets/d/1n27bC7lfRZxsHvPN3UghRA98E7jeVFsAdXInsZh9QEo/edit#gid=905649159)も対応済み
- 正しくレベルアップコストを指定できている？
    - 以前と変わらず薪を要求する？

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
