### PR TITLE
ポップアップがDestroyされない問題を修正

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/Extensions/Extensions.UI.ITweenPopup.cs
+++ b/Assets/HK/AutoAnt/Scripts/Extensions/Extensions.UI.ITweenPopup.cs
@@ -21,15 +21,14 @@ namespace HK.AutoAnt.Extensions
         {
             Broker.Global.Publish(PopupEvents.StartOpen.Get(self));
 
-            var onCompleteStreams = new List<IObservable<Unit>>();
+            var maxDuration = float.MinValue;
             foreach(var t in self.TweenAnimations)
             {
                 t.DOPlayForward();
-                onCompleteStreams.Add(t.onComplete.AsObservable());
+                maxDuration = Math.Max(maxDuration, t.duration);
             }
 
-            Observable.Zip(onCompleteStreams)
-                .Take(1)
+            Observable.Timer(TimeSpan.FromSeconds(maxDuration))
                 .SubscribeWithState(self, (_, _self) =>
                 {
                     Broker.Global.Publish(PopupEvents.CompleteOpen.Get(_self));
@@ -43,15 +42,14 @@ namespace HK.AutoAnt.Extensions
         {
             Broker.Global.Publish(PopupEvents.StartClose.Get(self));
 
-            var onCompleteStreams = new List<IObservable<Unit>>();
+            var maxDuration = float.MinValue;
             foreach (var t in self.TweenAnimations)
             {
                 t.DOPlayBackwards();
-                onCompleteStreams.Add(t.onComplete.AsObservable());
+                maxDuration = Math.Max(maxDuration, t.duration);
             }
 
-            Observable.Zip(onCompleteStreams)
-                .Take(1)
+            Observable.Timer(TimeSpan.FromSeconds(maxDuration))
                 .SubscribeWithState(self, (_, _self) =>
                 {
                     Broker.Global.Publish(PopupEvents.CompleteClose.Get(_self));


### PR DESCRIPTION
## 変更点概要
- #136 の対応
- （おそらく）Unity2019からTweenのonCompleteが閉じるときに実行されなくなった
- なのでアニメーションの再生時間をもとに完了処理を実行させてDestroyさせるようにしました

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 本当に死んでいる？
    - ポップアップを閉じたときに該当のオブジェクトがシーンから削除されていればOK
    - Hierarchyで`Popup`と検索して`PopupManager`しか存在しなければOK
## 特に見なくていい箇所
- 🍐 
## その他
- 🍐 
