### PR TITLE
全てのセルイベントをフッターメニューから建設出来るデバッグを追加

### DIFF
--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
@@ -171,6 +171,7 @@ public partial class SROptions
     {
         var footerController = GameObject.FindObjectOfType<FooterController>();
         footerController.ShowSelectBuilding(GameSystem.Instance.MasterData.CellEvent.Records);
+        SRDebug.Instance.HideDebugPanel();
     }
 }
 // #endif

--- a/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
+++ b/Assets/HK/AutoAnt/Scripts/DebugSystems/SROptions.Game.cs
@@ -163,5 +163,14 @@ public partial class SROptions
                 Debug.Log(x);
             });
     }
+
+    [Sort(1004)]
+    [Category("Game")]
+    [DisplayName("全てのセルイベントを建設")]
+    public void ShowFooterSelectCellEventAll()
+    {
+        var footerController = GameObject.FindObjectOfType<FooterController>();
+        footerController.ShowSelectBuilding(GameSystem.Instance.MasterData.CellEvent.Records);
+    }
 }
 // #endif


### PR DESCRIPTION
## 変更点概要
- #137 の対応
- SRDebug/Options/全てのセルイベントを建設でフッターメニューが全てのセルイベントを選択可能な状態で表示します

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 本当に選択できる？

## 特に見なくていい箇所
- 🍐 

## その他
- 🍐 
