### PR TITLE
QuickSheet周りの警告を修正

### DIFF
--- a/Assets/QuickSheet/GDataPlugin/Editor/GoogleDataSettings.cs
+++ b/Assets/QuickSheet/GDataPlugin/Editor/GoogleDataSettings.cs
@@ -86,7 +86,7 @@ namespace UnityQuickSheet
         /// <summary>
         /// Select currently exist account setting asset file.
         /// </summary>
-        [MenuItem("Edit/Project Settings/QuickSheet/Select Google Data Setting")]
+        [MenuItem("Edit/QuickSheet/Select Google Data Setting")]
         public static void Edit()
         {
             Selection.activeObject = Instance;


### PR DESCRIPTION
## 変更点概要
- #135 の対応
- `Project Settings...`に登録するほどでもないのでメニューの登録先を変更しただけ

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- 警告消えた？

## 特に見なくていい箇所
- 🍐 
## その他
- 🍐 