### PR TITLE
facilityにProductNumの概念追加

### DIFF
--- a/Assets/HK/AutoAnt/DataSources/Database/MasterData/FacilityLevelParameter.asset
+++ b/Assets/HK/AutoAnt/DataSources/Database/MasterData/FacilityLevelParameter.asset
@@ -18,13 +18,15 @@ MonoBehaviour:
     productSlot: 3
     productId: 100000
     needProductTime: 5
-    popularity: -10
+    productNum: 0
+    popularity: -30
     economic: 10
   - id: 101000
     level: 2
     productSlot: 5
     productId: 100000
     needProductTime: 5
+    productNum: 0
     popularity: -50
     economic: 15
   - id: 101000
@@ -32,6 +34,7 @@ MonoBehaviour:
     productSlot: 7
     productId: 100000
     needProductTime: 5
+    productNum: 0
     popularity: -120
     economic: 20
   - id: 101000
@@ -39,6 +42,7 @@ MonoBehaviour:
     productSlot: 9
     productId: 100000
     needProductTime: 5
+    productNum: 0
     popularity: -200
     economic: 25
   - id: 101000
@@ -46,5 +50,46 @@ MonoBehaviour:
     productSlot: 11
     productId: 100000
     needProductTime: 5
+    productNum: 0
     popularity: -400
     economic: 30
+  - id: 102000
+    level: 1
+    productSlot: 3
+    productId: 100000
+    needProductTime: 3
+    productNum: 0
+    popularity: -50
+    economic: 30
+  - id: 102000
+    level: 2
+    productSlot: 5
+    productId: 100000
+    needProductTime: 3
+    productNum: 0
+    popularity: -80
+    economic: 40
+  - id: 102000
+    level: 3
+    productSlot: 7
+    productId: 100000
+    needProductTime: 3
+    productNum: 0
+    popularity: -200
+    economic: 50
+  - id: 102000
+    level: 4
+    productSlot: 9
+    productId: 100000
+    needProductTime: 3
+    productNum: 0
+    popularity: -330
+    economic: 60
+  - id: 102000
+    level: 5
+    productSlot: 11
+    productId: 100000
+    needProductTime: 3
+    productNum: 0
+    popularity: -660
+    economic: 70

--- a/Assets/HK/AutoAnt/Editor/QuickSheetSettings/FacilityLevelParameter.asset
+++ b/Assets/HK/AutoAnt/Editor/QuickSheetSettings/FacilityLevelParameter.asset
@@ -39,6 +39,10 @@ MonoBehaviour:
     name: NeedProductTime
     isEnable: 0
     isArray: 0
+  - type: 3
+    name: productNum
+    isEnable: 0
+    isArray: 0
   - type: 6
     name: Popularity
     isEnable: 0

--- a/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Facility.cs
+++ b/Assets/HK/AutoAnt/Scripts/CellControllers/Events/Facility.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using HK.AutoAnt.Database;
 using HK.AutoAnt.Events;
 using HK.AutoAnt.Extensions;
@@ -77,7 +78,8 @@ namespace HK.AutoAnt.CellControllers.Events
                     if(_this.ProductTimer >= _this.LevelParameter.NeedProductTime)
                     {
                         var productId = _this.LevelParameter.ProductId;
-                        _this.Products.Add(productId);
+                        var productIds = Enumerable.Repeat<int>(productId, _this.LevelParameter.ProductNum).ToArray();
+                        _this.Products.AddRange(productIds);
                         var product = GameSystem.Instance.MasterData.Item.Records.Get(productId);
                         _this.Broker.Publish(AddedFacilityProduct.Get(_this, product));
                         _this.ProductTimer = 0.0f;

--- a/Assets/HK/AutoAnt/Scripts/Database/MasterDataFacilityLevelParameter.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/MasterDataFacilityLevelParameter.cs
@@ -51,6 +51,13 @@ namespace HK.AutoAnt.Database
             public float NeedProductTime => this.needProductTime;
 
             /// <summary>
+            /// NeedProductTimeごとに生産する量
+            /// </summary>
+            [SerializeField]
+            private int productNum = 0;
+            public int ProductNum => this.productNum;
+
+            /// <summary>
             /// 人気度
             /// </summary>
             [SerializeField]

--- a/Assets/HK/AutoAnt/Scripts/Database/Runtime/FacilityLevelParameterData.cs
+++ b/Assets/HK/AutoAnt/Scripts/Database/Runtime/FacilityLevelParameterData.cs
@@ -32,6 +32,10 @@ float needproducttime;
 public float Needproducttime { get {return needproducttime; } set { needproducttime = value;} }
 
 [SerializeField]
+int productnum;
+public int Productnum { get {return productnum; } set { productnum = value;} }
+
+[SerializeField]
 double popularity;
 public double Popularity { get {return popularity; } set { popularity = value;} }
 


### PR DESCRIPTION
## 変更点概要
- NeedProductTimeごとに１つ生産される状態だったので、一気に２つ以上生産できるようにした

## 依存するPR（先にマージする必要のあるPR）
- 🍐 

## 特に見てほしい箇所
- この状態でMasterDataDownloadしても値が反映されないので何が足りないか教えてほしい

## 特に見なくていい箇所
- 🍐 

## その他
- FacilityLevelParameterマスタには同名のカラムを追加したんだけどダウンロードしてくると初期値の０が入ってしまう。。。
